### PR TITLE
Enable GitHub Actions with instrumented tests on APIs 15-29

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,28 @@
+
+name: CI
+
+on:
+  push:
+    branches: master
+  pull_request:
+
+jobs:
+  build:
+    runs-on: macos-latest
+
+    strategy:
+      matrix:
+        api-level: [15, 16, 17, 18, 19, 21, 22, 23, 24, 25, 26, 27, 28, 29]
+
+    steps:
+      - name: Check out the repo
+        uses: actions/checkout@v2
+      - name: Validate Gradle wrapper
+        uses: gradle/wrapper-validation-action@v1
+      - name: Build
+        run: ./gradlew clean build --stacktrace
+      - name: Instrumented tests
+        uses: reactivecircus/android-emulator-runner@v2
+        with:
+          api-level: ${{ matrix.api-level }}
+          script: ./gradlew connectedCheck --stacktrace

--- a/deferred-resources/src/androidTest/java/com/backbase/android/res/deferred/ConfigurationContext.kt
+++ b/deferred-resources/src/androidTest/java/com/backbase/android/res/deferred/ConfigurationContext.kt
@@ -1,0 +1,36 @@
+package com.backbase.android.res.deferred
+
+import android.content.Context
+import android.content.ContextWrapper
+import android.content.res.Configuration
+import android.content.res.Resources
+
+/**
+ * An API < 17 alternative to [Context.createConfigurationContext]. It uses a deprecated function to copy [Resources]
+ * with the [overrideConfiguration].
+ *
+ * This should never be copied into production code.
+ */
+internal class ConfigurationContext(
+    base: Context,
+    private val overrideConfiguration: Configuration
+) : ContextWrapper(base) {
+
+    private var copiedResources: Resources? = null
+
+    override fun getResources(): Resources {
+        return copiedResources ?: synchronized<Resources>(this) {
+            var copiedResources = this.copiedResources
+            if (copiedResources == null) {
+                val originalResources = baseContext.resources
+
+                @Suppress("DEPRECATION")
+                copiedResources = Resources(
+                    originalResources.assets, originalResources.displayMetrics,
+                    overrideConfiguration
+                )
+            }
+            copiedResources
+        }
+    }
+}

--- a/deferred-resources/src/androidTest/java/com/backbase/android/res/deferred/DeferredDrawableTest.kt
+++ b/deferred-resources/src/androidTest/java/com/backbase/android/res/deferred/DeferredDrawableTest.kt
@@ -2,21 +2,28 @@ package com.backbase.android.res.deferred
 
 import android.graphics.Color
 import android.graphics.drawable.GradientDrawable
+import android.os.Build
 import androidx.core.content.ContextCompat
 import com.backbase.android.res.deferred.test.R
 import com.google.common.truth.Truth.assertThat
 import org.junit.After
+import org.junit.Assume.assumeFalse
 import org.junit.Test
 
 class DeferredDrawableTest {
+
+    private val defaultOvalGradientFraction = 0.8f
 
     /**
      * Some tests change drawables without mutating them, so the change persists. Reset after each test to avoid
      * messing with other tests.
      */
     @After fun restoreDrawables() {
+        // Radius XML is not honored on API 21, so mutate=false tests are skipped
+        if (Build.VERSION.SDK_INT == 21) return
+
         val loadedAgain = ContextCompat.getDrawable(context, R.drawable.oval) as GradientDrawable
-        loadedAgain.orientation = GradientDrawable.Orientation.LEFT_RIGHT
+        loadedAgain.gradientRadius = defaultOvalGradientFraction
     }
 
     @Test fun constant_returnsConstantValue() {
@@ -26,44 +33,59 @@ class DeferredDrawableTest {
     }
 
     @Test fun resource_withMutateFalse_resolvesWithContext() {
+        assumeFalse("XML drawable does not have correct radius on API 21", Build.VERSION.SDK_INT == 21)
+
         val deferred = DeferredDrawable.Resource(R.drawable.oval, mutate = false)
 
         val resolved = deferred.resolve(context)
         assertThat(resolved).isInstanceOf(GradientDrawable::class.java)
         resolved as GradientDrawable
-        assertThat(resolved.orientation).isEqualTo(GradientDrawable.Orientation.LEFT_RIGHT)
+        assertThat(resolved.gradientRadiusCompat).isEqualTo(defaultOvalGradientFraction)
 
-        resolved.orientation = GradientDrawable.Orientation.BOTTOM_TOP
+        resolved.gradientRadius = 0.5f
 
         // Since it's not mutated, transformations SHOULD apply to re-loaded instances:
         val loadedAgain = ContextCompat.getDrawable(context, R.drawable.oval) as GradientDrawable
-        assertThat(loadedAgain.orientation).isEqualTo(GradientDrawable.Orientation.BOTTOM_TOP)
+        assertThat(loadedAgain.gradientRadiusCompat).isEqualTo(0.5f)
     }
 
     @Test fun resource_withMutateTrue_resolvesWithContextAndMutates() {
+        assumeFalse("XML drawable does not have correct radius on API 21", Build.VERSION.SDK_INT == 21)
+
         val deferred = DeferredDrawable.Resource(R.drawable.oval)
 
         val resolved = deferred.resolve(context)
         assertThat(resolved).isInstanceOf(GradientDrawable::class.java)
         resolved as GradientDrawable
-        assertThat(resolved.orientation).isEqualTo(GradientDrawable.Orientation.LEFT_RIGHT)
+        assertThat(resolved.gradientRadiusCompat).isEqualTo(defaultOvalGradientFraction)
 
-        resolved.orientation = GradientDrawable.Orientation.BOTTOM_TOP
+        resolved.gradientRadius = 0.4f
 
         // Since it's mutated, transformations SHOULD NOT apply to re-loaded instances:
         val loadedAgain = ContextCompat.getDrawable(context, R.drawable.oval) as GradientDrawable
-        assertThat(loadedAgain.orientation).isEqualTo(GradientDrawable.Orientation.LEFT_RIGHT)
+        assertThat(loadedAgain.gradientRadiusCompat).isEqualTo(defaultOvalGradientFraction)
     }
 
     @Test fun resource_withTransformations_resolvesWithContextAndMutatesAndAppliesTransformation() {
         val deferred = DeferredDrawable.Resource(R.drawable.oval) {
             require(this is GradientDrawable)
-            orientation = GradientDrawable.Orientation.TOP_BOTTOM
+            gradientRadius = 0.3f
         }
 
         val resolved = deferred.resolve(context)
         assertThat(resolved).isInstanceOf(GradientDrawable::class.java)
         resolved as GradientDrawable
-        assertThat(resolved.orientation).isEqualTo(GradientDrawable.Orientation.TOP_BOTTOM)
+        assertThat(resolved.gradientRadiusCompat).isEqualTo(0.3f)
     }
+
+    private val GradientDrawable.gradientRadiusCompat: Float
+        get() = if (Build.VERSION.SDK_INT >= 21) gradientRadius else {
+            getPrivateField<Any>("mGradientState").getPrivateField("mGradientRadius")
+        }
+
+    @Suppress("UNCHECKED_CAST")
+    private fun <T : Any> Any.getPrivateField(name: String): T =
+        javaClass.getDeclaredField(name)
+            .apply { isAccessible = true }
+            .get(this) as T
 }

--- a/deferred-resources/src/androidTest/java/com/backbase/android/res/deferred/DeferredFormattedPluralsTest.kt
+++ b/deferred-resources/src/androidTest/java/com/backbase/android/res/deferred/DeferredFormattedPluralsTest.kt
@@ -1,10 +1,9 @@
 package com.backbase.android.res.deferred
 
 import android.icu.text.PluralRules
-import android.os.Build
+import androidx.test.filters.SdkSuppress
 import com.backbase.android.res.deferred.test.R
 import com.google.common.truth.Truth.assertThat
-import org.junit.Assume.assumeTrue
 import org.junit.Test
 
 class DeferredFormattedPluralsTest : SpecificLocaleTest() {
@@ -31,9 +30,8 @@ class DeferredFormattedPluralsTest : SpecificLocaleTest() {
         assertThat(deferred.resolve(context, 100, moose)).isEqualTo(someMoose)
     }
 
+    @SdkSuppress(minSdkVersion = 24)
     @Test fun constant_ordinalTypeAndUsLocale_resolvesOneTwoFewAndOther() {
-        assumeTrue("This constructor requires Android API 24", Build.VERSION.SDK_INT >= 24)
-
         setTestLanguage("en-US")
 
         val deferred = DeferredFormattedPlurals.Constant(

--- a/deferred-resources/src/androidTest/java/com/backbase/android/res/deferred/DeferredPluralsTest.kt
+++ b/deferred-resources/src/androidTest/java/com/backbase/android/res/deferred/DeferredPluralsTest.kt
@@ -2,12 +2,11 @@ package com.backbase.android.res.deferred
 
 import android.graphics.Typeface
 import android.icu.text.PluralRules
-import android.os.Build
 import android.text.SpannedString
 import android.text.style.StyleSpan
+import androidx.test.filters.SdkSuppress
 import com.backbase.android.res.deferred.test.R
 import com.google.common.truth.Truth.assertThat
-import org.junit.Assume.assumeTrue
 import org.junit.Test
 
 class DeferredPluralsTest : SpecificLocaleTest() {
@@ -33,9 +32,8 @@ class DeferredPluralsTest : SpecificLocaleTest() {
         assertThat(deferred.resolve(context, 100)).isEqualTo(some)
     }
 
+    @SdkSuppress(minSdkVersion = 24)
     @Test fun constant_ordinalTypeAndUsLocale_resolvesOneTwoFewAndOther() {
-        assumeTrue("This constructor requires Android API 24", Build.VERSION.SDK_INT >= 24)
-
         setTestLanguage("en-US")
 
         val some = "Some"

--- a/deferred-resources/src/androidTest/java/com/backbase/android/res/deferred/SpecificLocaleTest.kt
+++ b/deferred-resources/src/androidTest/java/com/backbase/android/res/deferred/SpecificLocaleTest.kt
@@ -27,7 +27,7 @@ abstract class SpecificLocaleTest {
         val newConfiguration = Configuration(context.resources.configuration).apply {
             setLocales(LocaleListCompat.forLanguageTags(language))
         }
-        context = context.createConfigurationContext(newConfiguration)
+        context = context.compatCreateConfigurationContext(newConfiguration)
     }
 
     private fun Configuration.setLocales(locales: LocaleListCompat) = when {

--- a/deferred-resources/src/androidTest/java/com/backbase/android/res/deferred/TestContext.kt
+++ b/deferred-resources/src/androidTest/java/com/backbase/android/res/deferred/TestContext.kt
@@ -1,8 +1,17 @@
 package com.backbase.android.res.deferred
 
+import android.content.Context
+import android.content.res.Configuration
+import android.os.Build
 import androidx.test.platform.app.InstrumentationRegistry
 
 /**
  * Quick access to the test context.
  */
 internal val context get() = InstrumentationRegistry.getInstrumentation().context
+
+internal fun Context.compatCreateConfigurationContext(overrideConfiguration: Configuration) =
+    if (Build.VERSION.SDK_INT >= 17)
+        createConfigurationContext(overrideConfiguration)
+    else
+        ConfigurationContext(this, overrideConfiguration)

--- a/deferred-resources/src/androidTest/res/drawable/oval.xml
+++ b/deferred-resources/src/androidTest/res/drawable/oval.xml
@@ -4,7 +4,8 @@
     android:shape="oval">
 
   <gradient
-      android:angle="0"
+      android:type="radial"
+      android:gradientRadius="0.8"
       android:startColor="#00ff00"
       android:endColor="#ffffff" />
 


### PR DESCRIPTION
- Create ContextWrapper for overridden configuration on API < 17
- Replace `assumeTrue` with `@SdkSuppress` where possible
- Manipulate gradient radius rather than orientation in tests to allow tests on API < 16
- Use reflection to test gradient radius on API < 21
- Ignore mutating Drawable tests on API 21 due to bad system behavior