### PR TITLE
Publish

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,26 @@
+
+name: Release
+
+on:
+  push:
+    branches: publish
+    tags: '*'
+
+jobs:
+  release:
+    runs-on: macos-latest
+
+    steps:
+      - name: Check out the repo
+        uses: actions/checkout@v2
+      - name: Validate Gradle wrapper
+        uses: gradle/wrapper-validation-action@v1
+      - name: Assemble for release
+        run: ./gradlew clean assembleRelease --stacktrace
+      - name: Publish
+        env:
+          ORG_GRADLE_PROJECT_backbaseOssSonatypeUsername: ${{ secrets.ORG_GRADLE_PROJECT_backbaseOssSonatypeUsername }}
+          ORG_GRADLE_PROJECT_backbaseOssSonatypePassword: ${{ secrets.ORG_GRADLE_PROJECT_backbaseOssSonatypePassword }}
+          ORG_GRADLE_PROJECT_backbaseOssGpgKey: ${{ secrets.ORG_GRADLE_PROJECT_backbaseOssGpgKey }}
+          ORG_GRADLE_PROJECT_backbaseOssGpgPassword: ${{ secrets.ORG_GRADLE_PROJECT_backbaseOssGpgPassword }}
+        run: ./gradlew publishReleasePublicationToMavenCentralRepository

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,7 +3,7 @@ name: Release
 
 on:
   push:
-    branches: publish
+    branches: master
     tags: '*'
 
 jobs:
@@ -23,4 +23,4 @@ jobs:
           ORG_GRADLE_PROJECT_backbaseOssSonatypePassword: ${{ secrets.ORG_GRADLE_PROJECT_backbaseOssSonatypePassword }}
           ORG_GRADLE_PROJECT_backbaseOssGpgKey: ${{ secrets.ORG_GRADLE_PROJECT_backbaseOssGpgKey }}
           ORG_GRADLE_PROJECT_backbaseOssGpgPassword: ${{ secrets.ORG_GRADLE_PROJECT_backbaseOssGpgPassword }}
-        run: ./gradlew publishReleasePublicationToMavenCentralRepository
+        run: ./gradlew publishReleasePublicationToMavenCentralRepository --stacktrace

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,7 @@
+# CHANGELOG
+
+## 0.1.0
+_2020-05-15_
+
+Initial preview release. Declare booleans, colors, dimensions, drawables, integers, plurals, and
+text from resources or code without a Context, relying on the consumer to resolve them.

--- a/README.md
+++ b/README.md
@@ -9,7 +9,9 @@ layers to remain ignorant of Android's Context.
 ## Download
 [![Maven Central](https://maven-badges.herokuapp.com/maven-central/com.backbase.oss.deferredresources/deferred-resources/badge.svg)](https://maven-badges.herokuapp.com/maven-central/com.backbase.oss.deferredresources/deferred-resources)
 
-Deferred Resources is available on Maven Central.
+Deferred Resources is available on Maven Central. Snapshots of the development version are available
+in [Sonatype's Snapshots
+repository](https://oss.sonatype.org/#view-repositories;snapshots~browsestorage).
 
 ```groovy
 implementation "com.backbase.oss.deferredresources:deferred-resources:$version"

--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 # Deferred Resources
+[![](https://github.com/Backbase/DeferredResources/workflows/CI/badge.svg?branch=master)](https://github.com/Backbase/DeferredResources/actions?query=workflow%3ACI+branch%3Amaster)
 
 An Android library that decouples resource declaration (without Context) from resource resolution
 (with Context). This allows the resolver (Activity, Fragment, or View) to be agnostic to the source
@@ -6,8 +7,13 @@ An Android library that decouples resource declaration (without Context) from re
 layers to remain ignorant of Android's Context.
 
 ## Download
+[![Maven Central](https://maven-badges.herokuapp.com/maven-central/com.backbase.oss.deferredresources/deferred-resources/badge.svg)](https://maven-badges.herokuapp.com/maven-central/com.backbase.oss.deferredresources/deferred-resources)
 
-Deferred Resources is not yet available on Maven Central.
+Deferred Resources is available on Maven Central.
+
+```groovy
+implementation "com.backbase.oss.deferredresources:deferred-resources:$version"
+```
 
 ## Use
 
@@ -15,6 +21,7 @@ In the view layer, resolve a deferred resource to display it:
 ```kotlin
 val text: DeferredText = respository.getText()
 val textColor: DeferredColor = repository.getTextColor()
+textView.text = text.resolve(context)
 textView.setTextColor(textColor.resolve(context))
 ```
 
@@ -26,7 +33,7 @@ class LocalRepository : Repository {
     override fun getTextColor(): DeferredColor = DeferredColor.Attribute(R.attr.colorOnBackground)
 }
 
-class RemoteRepository(private val api: Api) : Respository {
+class RemoteRepository(private val api: Api) : Repository {
     override fun getText(): DeferredText = DeferredText.Constant(api.fetchText())
     override fun getTextColor(): DeferredColor = DeferredColor.Constant(api.fetchTextColor())
 }

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,11 +1,15 @@
 # Releasing
 
-1. Make sure you're on the master branch.
-2. Change `ext.libraryVersion` in root build.gradle.
-3. Update CHANGELOG.md for the impending release.
-4. If necessary, update README.md.
-5. `./gradlew clean assembleRelease && ./gradlew publishReleasePublicationToMavenCentralRepository`
-6. Visit [Sonatype Nexus](https://oss.sonatype.org/#stagingRepositories). Verify the artifacts,
-   close the staging repository, and release the closed staging repository.
-7. Commit and push the release changes to master.
-8. Create the release tag on GitHub with release notes copied from the changelog.
+ 1. Make sure you're on the master branch.
+ 2. Change `ext.libraryVersion` in the root build.gradle to a non-SNAPSHOT version.
+ 3. Update CHANGELOG.md for the impending release.
+ 4. If necessary, update README.md.
+ 5. Commit (don't push) the changes with message "Release x.y.z" and tag the commit `x.y.z`, where
+    `x.y.z` is the new version.
+ 6. Change `ext.libraryVersion` in the root build.gradle to the next SNAPSHOT version.
+ 7. Commit the SNAPSHOT change.
+ 8. Push the 2 commits + 1 tag to origin/master.
+ 9. Wait for the "release" Action to complete.
+10. Visit [Sonatype Nexus](https://oss.sonatype.org/#stagingRepositories). Verify the artifacts,
+    close the staging repository, and release the closed staging repository.
+11. Create the release on GitHub with release notes copied from the changelog.

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -4,12 +4,14 @@
  2. Change `ext.libraryVersion` in the root build.gradle to a non-SNAPSHOT version.
  3. Update CHANGELOG.md for the impending release.
  4. If necessary, update README.md.
- 5. Commit (don't push) the changes with message "Release x.y.z" and tag the commit `x.y.z`, where
-    `x.y.z` is the new version.
- 6. Change `ext.libraryVersion` in the root build.gradle to the next SNAPSHOT version.
- 7. Commit the SNAPSHOT change.
- 8. Push the 2 commits + 1 tag to origin/master.
- 9. Wait for the "release" Action to complete.
-10. Visit [Sonatype Nexus](https://oss.sonatype.org/#stagingRepositories). Verify the artifacts,
+ 5. Commit (don't push) the changes with message "Release x.y.z", where x.y.z is the new version.
+ 6. Tag the commit `x.y.z`, where x.y.z is the new version.
+ 7. Change `ext.libraryVersion` in the root build.gradle to the next SNAPSHOT version.
+ 8. Commit the SNAPSHOT change.
+ 9. Push the 2 commits + 1 tag to origin/master.
+10. Wait for the "release" Action to complete.
+11. Visit [Sonatype Nexus](https://oss.sonatype.org/#stagingRepositories). Verify the artifacts,
     close the staging repository, and release the closed staging repository.
-11. Create the release on GitHub with release notes copied from the changelog.
+12. Create the release on GitHub with release notes copied from the changelog.
+
+If step 9 fails, drop the Sonatype repo, fix the problem, commit, and start again at step 6.

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,0 +1,11 @@
+# Releasing
+
+1. Make sure you're on the master branch.
+2. Change `ext.libraryVersion` in root build.gradle.
+3. Update CHANGELOG.md for the impending release.
+4. If necessary, update README.md.
+5. `./gradlew clean assembleRelease && ./gradlew publishReleasePublicationToMavenCentralRepository`
+6. Visit [Sonatype Nexus](https://oss.sonatype.org/#stagingRepositories). Verify the artifacts,
+   close the staging repository, and release the closed staging repository.
+7. Commit and push the release changes to master.
+8. Create the release tag on GitHub with release notes copied from the changelog.

--- a/build.gradle
+++ b/build.gradle
@@ -37,7 +37,7 @@ buildscript {
 
 ext {
     publishGroup = 'com.backbase.oss.deferredresources'
-    libraryVersion = '0.1.0'
+    libraryVersion = '0.1.0-SNAPSHOT'
     minSdk = 14
     targetSdk = 29
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -25,3 +25,6 @@ android.enableJetifier=true
 
 # Kotlin code style for this project: "official" or "obsolete":
 kotlin.code.style=official
+
+# TODO WORKAROUND: https://issues.sonatype.org/browse/NEXUS-21802 + https://github.com/gradle/gradle/issues/11308
+systemProp.org.gradle.internal.publish.checksums.insecure=true

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.3-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.4-all.zip

--- a/publish.gradle
+++ b/publish.gradle
@@ -55,6 +55,7 @@ afterEvaluate {
                     developers {
                         developer {
                             name = 'Backbase R&D B.V.'
+                            email = 'oss@backbase.com'
                         }
                     }
 
@@ -87,9 +88,9 @@ afterEvaluate {
 }
 
 apply plugin: 'signing'
-ext.'signing.keyId' = hasProperty('backbaseOssGpgKeyId') ? backbaseOssGpgKeyId : 'x'
-ext.'signing.password' = hasProperty('backbaseOssGpgPassword') ? backbaseOssGpgPassword : 'x'
-ext.'signing.secretKeyRingFile' = hasProperty('backbaseOssGpgKeyringFile') ? backbaseOssGpgKeyringFile : 'x'
 signing {
+    def key = findProperty('backbaseOssGpgKey')
+    def password = findProperty('backbaseOssGpgPassword')
+    useInMemoryPgpKeys(key, password)
     sign publishing.publications
 }

--- a/publish.gradle
+++ b/publish.gradle
@@ -76,8 +76,8 @@ afterEvaluate {
                 def snapshotsRepoUrl = 'https://oss.sonatype.org/content/repositories/snapshots/'
                 url = version.endsWith('SNAPSHOT') ? snapshotsRepoUrl : releasesRepoUrl
 
-                def sonatypeUsername = project.hasProperty('backbaseSonatypeUsername') ? backbaseSonatypeUsername : 'x'
-                def sonatypePassword = project.hasProperty('backbaseSonatypePassword') ? backbaseSonatypePassword : 'x'
+                def sonatypeUsername = findProperty('backbaseOssSonatypeUsername')
+                def sonatypePassword = findProperty('backbaseOssSonatypePassword')
                 credentials {
                     username sonatypeUsername
                     password sonatypePassword


### PR DESCRIPTION
Closes #4.

Publish to Maven Central using Backbase's OSS signing key. Also publish snapshots to Sonatype's Snapshots repository.

Add RELEASING.md checklist for a consistent release process. Add CHANGELOG.md for tracking what changes in each release.