### PR TITLE
Deferred text and integer arrays

### DIFF
--- a/deferred-resources/api/deferred-resources.api
+++ b/deferred-resources/api/deferred-resources.api
@@ -174,6 +174,27 @@ public final class com/backbase/deferredresources/DeferredInteger$Resource : com
 	public fun toString ()Ljava/lang/String;
 }
 
+public abstract interface class com/backbase/deferredresources/DeferredIntegerArray {
+	public abstract fun resolve (Landroid/content/Context;)[I
+}
+
+public final class com/backbase/deferredresources/DeferredIntegerArray$Constant : com/backbase/deferredresources/DeferredIntegerArray {
+	public fun <init> (Ljava/util/Collection;)V
+	public fun <init> ([I)V
+	public fun equals (Ljava/lang/Object;)Z
+	public fun hashCode ()I
+	public fun resolve (Landroid/content/Context;)[I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/backbase/deferredresources/DeferredIntegerArray$Resource : com/backbase/deferredresources/DeferredIntegerArray {
+	public fun <init> (I)V
+	public fun equals (Ljava/lang/Object;)Z
+	public fun hashCode ()I
+	public fun resolve (Landroid/content/Context;)[I
+	public fun toString ()Ljava/lang/String;
+}
+
 public abstract interface class com/backbase/deferredresources/DeferredPlurals {
 	public abstract fun resolve (Landroid/content/Context;I)Ljava/lang/CharSequence;
 }

--- a/deferred-resources/api/deferred-resources.api
+++ b/deferred-resources/api/deferred-resources.api
@@ -234,6 +234,36 @@ public final class com/backbase/deferredresources/DeferredText$Resource$Type : j
 	public static fun values ()[Lcom/backbase/deferredresources/DeferredText$Resource$Type;
 }
 
+public abstract interface class com/backbase/deferredresources/DeferredTextArray {
+	public abstract fun resolve (Landroid/content/Context;)[Ljava/lang/CharSequence;
+}
+
+public final class com/backbase/deferredresources/DeferredTextArray$Constant : com/backbase/deferredresources/DeferredTextArray {
+	public fun <init> (Ljava/util/Collection;)V
+	public fun <init> ([Ljava/lang/CharSequence;)V
+	public fun equals (Ljava/lang/Object;)Z
+	public fun hashCode ()I
+	public fun resolve (Landroid/content/Context;)[Ljava/lang/CharSequence;
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/backbase/deferredresources/DeferredTextArray$Resource : com/backbase/deferredresources/DeferredTextArray {
+	public fun <init> (I)V
+	public fun <init> (ILcom/backbase/deferredresources/DeferredTextArray$Resource$Type;)V
+	public synthetic fun <init> (ILcom/backbase/deferredresources/DeferredTextArray$Resource$Type;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun equals (Ljava/lang/Object;)Z
+	public fun hashCode ()I
+	public fun resolve (Landroid/content/Context;)[Ljava/lang/CharSequence;
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/backbase/deferredresources/DeferredTextArray$Resource$Type : java/lang/Enum {
+	public static final field STRING Lcom/backbase/deferredresources/DeferredTextArray$Resource$Type;
+	public static final field TEXT Lcom/backbase/deferredresources/DeferredTextArray$Resource$Type;
+	public static fun valueOf (Ljava/lang/String;)Lcom/backbase/deferredresources/DeferredTextArray$Resource$Type;
+	public static fun values ()[Lcom/backbase/deferredresources/DeferredTextArray$Resource$Type;
+}
+
 public abstract interface class com/backbase/deferredresources/DeferredTypeface {
 	public abstract fun resolve (Landroid/content/Context;)Landroid/graphics/Typeface;
 	public abstract fun resolve (Landroid/content/Context;Landroidx/core/content/res/ResourcesCompat$FontCallback;Landroid/os/Handler;)V

--- a/deferred-resources/src/androidTest/java/com/backbase/deferredresources/DeferredIntegerArrayJavaTest.java
+++ b/deferred-resources/src/androidTest/java/com/backbase/deferredresources/DeferredIntegerArrayJavaTest.java
@@ -1,0 +1,20 @@
+package com.backbase.deferredresources;
+
+import java.util.Collections;
+import org.junit.Test;
+
+import static com.google.common.truth.Truth.assertThat;
+
+public class DeferredIntegerArrayJavaTest {
+
+    // This test is impossible in Kotlin because Kotlin enforces spreading the original array when passed as a vararg
+    @Test
+    public void constant_initializedWithArray_doesNotReflectLaterArrayChanges() {
+        int[] originalArray = new int[]{1};
+        DeferredIntegerArray deferred = new DeferredIntegerArray.Constant(originalArray);
+        originalArray[0] = 99;
+
+        int[] resolved = deferred.resolve(TestContext.getContext());
+        assertThat(resolved).asList().isEqualTo(Collections.singletonList(1));
+    }
+}

--- a/deferred-resources/src/androidTest/java/com/backbase/deferredresources/DeferredIntegerArrayTest.kt
+++ b/deferred-resources/src/androidTest/java/com/backbase/deferredresources/DeferredIntegerArrayTest.kt
@@ -1,0 +1,76 @@
+package com.backbase.deferredresources
+
+import com.backbase.deferredresources.test.R
+import com.google.common.truth.Truth.assertThat
+import org.junit.Test
+
+class DeferredIntegerArrayTest {
+
+    private val expectedIntArray = intArrayOf(101, 103)
+
+    @Test fun constant_returnsConstantValues() {
+        val deferred = DeferredIntegerArray.Constant(9, 8)
+        assertThat(deferred.resolve(context)).asList().isEqualTo(listOf(9, 8))
+    }
+
+    @Test fun constant_initializedWithList_returnsConstantValues() {
+        val originalList = mutableListOf(1)
+        val deferred = DeferredIntegerArray.Constant(originalList)
+        originalList[0] = 99
+
+        assertThat(deferred.resolve(context)).asList().isEqualTo(listOf(1))
+    }
+
+    @Test fun constant_arrayChangedAfterResolved_doesNotAffectRepeatedResolutions() {
+        val deferred: DeferredIntegerArray = DeferredIntegerArray.Constant(1)
+
+        val resolved1 = deferred.resolve(context)
+        resolved1[0] = 2
+
+        val resolved2 = deferred.resolve(context)
+        assertThat(resolved2).asList().isEqualTo(listOf(1))
+    }
+
+    @Test fun constant_equals_basedOnContents() {
+        val deferredA1 = DeferredIntegerArray.Constant(1)
+        val deferredA2 = DeferredIntegerArray.Constant(1)
+        val deferredAB = DeferredIntegerArray.Constant(1, 2)
+
+        assertThat(deferredA1).isEqualTo(deferredA2)
+        assertThat(deferredA1.hashCode()).isEqualTo(deferredA2.hashCode())
+        assertThat(deferredA1).isNotEqualTo(deferredAB)
+        assertThat(deferredA1.hashCode()).isNotEqualTo(deferredAB.hashCode())
+
+        assertThat(deferredA2).isEqualTo(deferredA1)
+        assertThat(deferredA2.hashCode()).isEqualTo(deferredA1.hashCode())
+        assertThat(deferredA2).isNotEqualTo(deferredAB)
+        assertThat(deferredA2.hashCode()).isNotEqualTo(deferredAB.hashCode())
+
+        assertThat(deferredAB).isNotEqualTo(deferredA1)
+        assertThat(deferredAB.hashCode()).isNotEqualTo(deferredA1.hashCode())
+        assertThat(deferredAB).isNotEqualTo(deferredA2)
+        assertThat(deferredAB.hashCode()).isNotEqualTo(deferredA2.hashCode())
+    }
+
+    @Test fun constant_toString_includesContents() {
+        val deferred = DeferredIntegerArray.Constant(1, 0)
+        assertThat(deferred.toString()).isEqualTo("Constant(values=[1, 0])")
+    }
+
+    @Test fun resource_resolvesIntegersWithContext() {
+        val deferred = DeferredIntegerArray.Resource(R.array.integerArray)
+
+        val resolved = deferred.resolve(context)
+        assertThat(resolved).asList().isEqualTo(expectedIntArray.asList())
+    }
+
+    @Test fun resource_arrayChangedAfterResolved_doesNotAffectRepeatedResolutions() {
+        val deferred: DeferredIntegerArray = DeferredIntegerArray.Resource(R.array.integerArray)
+
+        val resolved1 = deferred.resolve(context)
+        resolved1[0] = 102
+
+        val resolved2 = deferred.resolve(context)
+        assertThat(resolved2[0]).isEqualTo(101)
+    }
+}

--- a/deferred-resources/src/androidTest/java/com/backbase/deferredresources/DeferredTextArrayJavaTest.java
+++ b/deferred-resources/src/androidTest/java/com/backbase/deferredresources/DeferredTextArrayJavaTest.java
@@ -1,0 +1,46 @@
+package com.backbase.deferredresources;
+
+import com.backbase.deferredresources.test.R;
+import java.util.Arrays;
+import java.util.Collections;
+import org.junit.Test;
+
+import static com.google.common.truth.Truth.assertThat;
+
+public class DeferredTextArrayJavaTest {
+
+    // This test is impossible in Kotlin because Kotlin enforces spreading the original array when passed as a vararg
+    @Test
+    public void constant_initializedWithArray_doesNotReflectLaterArrayChanges() {
+        String[] originalArray = new String[]{"A"};
+        DeferredTextArray deferred = new DeferredTextArray.Constant(originalArray);
+        originalArray[0] = "Z";
+
+        CharSequence[] resolved = deferred.resolve(TestContext.getContext());
+        assertThat(Arrays.asList(resolved)).isEqualTo(Collections.singletonList("A"));
+    }
+
+    // This test is impossible in Kotlin because Kotlin prevents writing to an Array<out T> thanks to type projection
+    @Test
+    public void constant_arrayChangedAfterResolved_doesNotAffectRepeatedResolutions() {
+        DeferredTextArray deferred = new DeferredTextArray.Constant("A");
+
+        CharSequence[] resolved1 = deferred.resolve(TestContext.getContext());
+        resolved1[0] = "B";
+
+        CharSequence[] resolved2 = deferred.resolve(TestContext.getContext());
+        assertThat(Arrays.asList(resolved2)).isEqualTo(Collections.singletonList("A"));
+    }
+
+    // This test is impossible in Kotlin because Kotlin prevents writing to an Array<out T> thanks to type projection
+    @Test
+    public void resource_arrayChangedAfterResolved_doesNotAffectRepeatedResolutions() {
+        DeferredTextArray deferred = new DeferredTextArray.Resource(R.array.stringArray);
+
+        CharSequence[] resolved1 = deferred.resolve(TestContext.getContext());
+        resolved1[0] = "Wrong one";
+
+        CharSequence[] resolved2 = deferred.resolve(TestContext.getContext());
+        assertThat(resolved2[0]).isEqualTo("Bold one");
+    }
+}

--- a/deferred-resources/src/androidTest/java/com/backbase/deferredresources/DeferredTextArrayTest.kt
+++ b/deferred-resources/src/androidTest/java/com/backbase/deferredresources/DeferredTextArrayTest.kt
@@ -1,0 +1,88 @@
+package com.backbase.deferredresources
+
+import android.graphics.Typeface
+import android.text.SpannedString
+import android.text.style.StyleSpan
+import com.backbase.deferredresources.test.R
+import com.google.common.truth.Truth.assertThat
+import org.junit.Test
+
+class DeferredTextArrayTest {
+
+    private val expectedStringArray = arrayOf("Bold one", "Regular one")
+
+    @Test fun constant_returnsConstantValues() {
+        val deferred = DeferredTextArray.Constant("Some text", "More text")
+        assertThat(deferred.resolve(context).asList()).isEqualTo(listOf("Some text", "More text"))
+    }
+
+    @Test fun constant_initializedWithList_returnsConstantValues() {
+        val originalList = mutableListOf("A")
+        val deferred = DeferredTextArray.Constant(originalList)
+        originalList[0] = "Z"
+
+        assertThat(deferred.resolve(context).asList()).isEqualTo(listOf("A"))
+    }
+
+    @Test fun constant_equals_basedOnContents() {
+        val deferredA1 = DeferredTextArray.Constant("A")
+        val deferredA2 = DeferredTextArray.Constant("A")
+        val deferredAB = DeferredTextArray.Constant("A", "B")
+
+        assertThat(deferredA1).isEqualTo(deferredA2)
+        assertThat(deferredA1.hashCode()).isEqualTo(deferredA2.hashCode())
+        assertThat(deferredA1).isNotEqualTo(deferredAB)
+        assertThat(deferredA1.hashCode()).isNotEqualTo(deferredAB.hashCode())
+
+        assertThat(deferredA2).isEqualTo(deferredA1)
+        assertThat(deferredA2.hashCode()).isEqualTo(deferredA1.hashCode())
+        assertThat(deferredA2).isNotEqualTo(deferredAB)
+        assertThat(deferredA2.hashCode()).isNotEqualTo(deferredAB.hashCode())
+
+        assertThat(deferredAB).isNotEqualTo(deferredA1)
+        assertThat(deferredAB.hashCode()).isNotEqualTo(deferredA1.hashCode())
+        assertThat(deferredAB).isNotEqualTo(deferredA2)
+        assertThat(deferredAB.hashCode()).isNotEqualTo(deferredA2.hashCode())
+    }
+
+    @Test fun constant_toString_includesContents() {
+        val deferred = DeferredTextArray.Constant("Yes", "No")
+        assertThat(deferred.toString()).isEqualTo("Constant(values=[Yes, No])")
+    }
+
+    @Test fun resource_withTypeString_resolvesStringsWithContext() {
+        val deferred = DeferredTextArray.Resource(R.array.stringArray)
+
+        val resolved = deferred.resolve(context)
+        assertThat(resolved.asList()).isEqualTo(expectedStringArray.asList())
+        resolved.forEach { item ->
+            assertThat(item).isInstanceOf(String::class.java)
+        }
+    }
+
+    @Test fun resource_withTypeText_resolvesTextWithContext() {
+        val deferred = DeferredTextArray.Resource(R.array.stringArray, type = DeferredTextArray.Resource.Type.TEXT)
+
+        val resolved = deferred.resolve(context)
+
+        resolved.forEachIndexed { index, item ->
+            assertThat(item.toString()).isEqualTo(expectedStringArray[index])
+        }
+
+        val boldItem = resolved[0]
+        // Verify the resolved value is not a plain string:
+        assertThat(boldItem).isInstanceOf(SpannedString::class.java)
+        boldItem as SpannedString
+
+        // Verify the resolved value has a single BOLD style span:
+        val spans = boldItem.getSpans(0, boldItem.length, Object::class.java)
+        assertThat(spans.size).isEqualTo(1)
+        val span = spans[0]
+        assertThat(span).isInstanceOf(StyleSpan::class.java)
+        span as StyleSpan
+        assertThat(span.style).isEqualTo(Typeface.BOLD)
+
+        val regularItem = resolved[1]
+        assertThat(regularItem).isInstanceOf(String::class.java)
+    }
+}

--- a/deferred-resources/src/androidTest/java/com/backbase/deferredresources/TestContext.kt
+++ b/deferred-resources/src/androidTest/java/com/backbase/deferredresources/TestContext.kt
@@ -1,3 +1,5 @@
+@file:JvmName("TestContext")
+
 package com.backbase.deferredresources
 
 import android.content.Context

--- a/deferred-resources/src/androidTest/res/values/test_values.xml
+++ b/deferred-resources/src/androidTest/res/values/test_values.xml
@@ -24,4 +24,9 @@
   <string name="formattedString">This is %1$s text.</string>
   <string name="plainString">A string</string>
   <string name="richText"><b>Rich</b> text</string>
+
+  <string-array name="stringArray">
+    <item><b>Bold one</b></item>
+    <item>Regular one</item>
+  </string-array>
 </resources>

--- a/deferred-resources/src/androidTest/res/values/test_values.xml
+++ b/deferred-resources/src/androidTest/res/values/test_values.xml
@@ -8,6 +8,11 @@
 
   <integer name="five">5</integer>
 
+  <integer-array name="integerArray">
+    <item>101</item>
+    <item>103</item>
+  </integer-array>
+
   <plurals name="plainPlurals">
     <item quantity="one">Car</item>
     <item quantity="other">Cars</item>

--- a/deferred-resources/src/main/java/com/backbase/deferredresources/DeferredIntegerArray.kt
+++ b/deferred-resources/src/main/java/com/backbase/deferredresources/DeferredIntegerArray.kt
@@ -1,0 +1,72 @@
+package com.backbase.deferredresources
+
+import android.content.Context
+import androidx.annotation.ArrayRes
+import dev.drewhamilton.extracare.DataApi
+
+/**
+ * A wrapper for resolving an integer array on demand.
+ */
+interface DeferredIntegerArray {
+
+    /**
+     * Resolve the integer array.
+     */
+    fun resolve(context: Context): IntArray
+
+    /**
+     * A wrapper for a constant array of integer [values].
+     *
+     * This class protects against array mutability by holding a copy of the input [values] and by always returning a
+     * new copy of those [values] when resolved.
+     */
+    @DataApi class Constant private constructor(
+        // Private constructor marker allows vararg constructor overload while retaining DataApi toString generation
+        @Suppress("UNUSED_PARAMETER") privateConstructorMarker: Char,
+        private val values: IntArray
+    ) : DeferredIntegerArray {
+
+        /**
+         * Initialize with the given integer [values].
+         *
+         * The given [values] array is copied on construction, so later external changes to the original will not be
+         * reflected in this [DeferredIntegerArray].
+         */
+        constructor(vararg values: Int) : this('x', intArrayOf(*values))
+
+        /**
+         * Convenience for initializing with a [Collection] of integer [values].
+         */
+        constructor(values: Collection<Int>) : this('x', values.toIntArray())
+
+        /**
+         * Always resolves to a new array copied from [values]. Changes to the returned array will not be reflected in
+         * future calls to resolve this [DeferredIntegerArray].
+         */
+        override fun resolve(context: Context): IntArray = values.copyOf()
+
+        /**
+         * Two instances of [DeferredIntegerArray.Constant] are considered equals if they hold the same number of
+         * integer values and each integer value in this instance is equal to the corresponding integer value in
+         * [other].
+         */
+        override fun equals(other: Any?): Boolean = other is Constant && values.contentEquals(other.values)
+
+        /**
+         * Equal to the hash code of this instance's integer values plus an offset.
+         */
+        override fun hashCode(): Int = 103 + values.contentHashCode()
+    }
+
+    /**
+     * A wrapper for an integer [ArrayRes] [id].
+     */
+    @DataApi class Resource(
+        @ArrayRes private val id: Int
+    ) : DeferredIntegerArray {
+        /**
+         * Resolve [id] to an integer array with the given [context].
+         */
+        override fun resolve(context: Context): IntArray = context.resources.getIntArray(id)
+    }
+}

--- a/deferred-resources/src/main/java/com/backbase/deferredresources/DeferredTextArray.kt
+++ b/deferred-resources/src/main/java/com/backbase/deferredresources/DeferredTextArray.kt
@@ -2,7 +2,6 @@ package com.backbase.deferredresources
 
 import android.content.Context
 import androidx.annotation.ArrayRes
-import com.backbase.deferredresources.DeferredTextArray.Resource.Type
 import dev.drewhamilton.extracare.DataApi
 
 /**
@@ -18,8 +17,8 @@ interface DeferredTextArray {
     /**
      * A wrapper for a constant array of text [values].
      *
-     * This class protect against mutability of by holding a copy of the input [values] and by always returning a new
-     * copy of those [values] when resolved.
+     * This class protects against array mutability by holding a copy of the input [values] and by always returning a
+     * new copy of those [values] when resolved.
      */
     @DataApi class Constant private constructor(
         // Private constructor marker allows vararg constructor overload while retaining DataApi toString generation

--- a/deferred-resources/src/main/java/com/backbase/deferredresources/DeferredTextArray.kt
+++ b/deferred-resources/src/main/java/com/backbase/deferredresources/DeferredTextArray.kt
@@ -1,0 +1,92 @@
+package com.backbase.deferredresources
+
+import android.content.Context
+import androidx.annotation.ArrayRes
+import com.backbase.deferredresources.DeferredTextArray.Resource.Type
+import dev.drewhamilton.extracare.DataApi
+
+/**
+ * A wrapper for resolving a text array on demand.
+ */
+interface DeferredTextArray {
+
+    /**
+     * Resolve the text array.
+     */
+    fun resolve(context: Context): Array<out CharSequence>
+
+    /**
+     * A wrapper for a constant array of text [values].
+     *
+     * This class protect against mutability of by holding a copy of the input [values] and by always returning a new
+     * copy of those [values] when resolved.
+     */
+    @DataApi class Constant private constructor(
+        // Private constructor marker allows vararg constructor overload while retaining DataApi toString generation
+        @Suppress("UNUSED_PARAMETER") privateConstructorMarker: Int,
+        private val values: Array<out CharSequence>
+    ) : DeferredTextArray {
+
+        /**
+         * Initialize with the given text [values].
+         *
+         * The given [values] array is copied on construction, so later external changes to the original will not be
+         * reflected in this [DeferredTextArray].
+         */
+        constructor(vararg values: CharSequence) : this(1, arrayOf(*values))
+
+        /**
+         * Convenience for initializing with a [Collection] of text [values].
+         */
+        constructor(values: Collection<CharSequence>) : this(1, values.toTypedArray())
+
+        /**
+         * Always resolves to a new array copied from [values]. Changes to the returned array will not be reflected in
+         * future calls to resolve this [DeferredTextArray].
+         */
+        override fun resolve(context: Context): Array<out CharSequence> = values.copyOf()
+
+        /**
+         * Two instances of [DeferredTextArray.Constant] are considered equals if they hold the same number of text
+         * values and each text value in this instance is equal to the corresponding text value in [other].
+         */
+        override fun equals(other: Any?): Boolean = other is Constant && values.contentEquals(other.values)
+
+        /**
+         * Equal to the hash code of this instance's text values plus an offset.
+         */
+        override fun hashCode(): Int = 101 + values.contentHashCode()
+    }
+
+    /**
+     * A wrapper for a text [ArrayRes] [id]. Optionally set [type] to [Type.TEXT] to retain style information in each
+     * resource.
+     */
+    @DataApi class Resource @JvmOverloads constructor(
+        @ArrayRes private val id: Int,
+        private val type: Type = Type.STRING
+    ) : DeferredTextArray {
+        /**
+         * Resolve [id] to a text array with the given [context].
+         *
+         * If [type] is [Type.STRING], resolves an array of (un-styled) strings. If [type] is [Type.TEXT], resolves an
+         * array of styled [CharSequence]s.
+         *
+         * @see android.content.res.Resources.getStringArray
+         * @see android.content.res.Resources.getTextArray
+         */
+        override fun resolve(context: Context): Array<out CharSequence> = when (type) {
+            Type.STRING -> context.resources.getStringArray(id)
+            Type.TEXT -> context.resources.getTextArray(id)
+        }
+
+        /**
+         * The type of text resource to resolve.
+         */
+        enum class Type {
+            STRING, TEXT
+        }
+    }
+
+
+}


### PR DESCRIPTION
Implement `DeferredTextArray` and `DeferredIntegerArray`. The `Constant` variant is somewhat complex due to care taken around mutability of arrays.

TypedArray wrapping requires more thought, so is left for another day.