### PR TITLE
Update compatibility from Java 6 to Java 8

### DIFF
--- a/deferred-resources/build.gradle
+++ b/deferred-resources/build.gradle
@@ -27,6 +27,15 @@ android {
             minifyEnabled false
         }
     }
+
+    compileOptions {
+        sourceCompatibility JavaVersion.VERSION_1_8
+        targetCompatibility JavaVersion.VERSION_1_8
+    }
+
+    kotlinOptions {
+        jvmTarget = JavaVersion.VERSION_1_8
+    }
 }
 
 dependencies {


### PR DESCRIPTION
This isn't strictly needed in the current code base, but futureproofs us if we want to e.g. use `@JvmDefault` in the future.