### PR TITLE
Add explicit return types for all public functions

### DIFF
--- a/deferred-resources/src/main/java/com/backbase/deferredresources/DeferredBoolean.kt
+++ b/deferred-resources/src/main/java/com/backbase/deferredresources/DeferredBoolean.kt
@@ -26,7 +26,7 @@ interface DeferredBoolean {
         /**
          * Always resolves to [value], ignoring [context].
          */
-        override fun resolve(context: Context) = value
+        override fun resolve(context: Context): Boolean = value
     }
 
     /**
@@ -38,7 +38,7 @@ interface DeferredBoolean {
         /**
          * Resolve [resId] to a boolean with the given [context].
          */
-        override fun resolve(context: Context) = context.resources.getBoolean(resId)
+        override fun resolve(context: Context): Boolean = context.resources.getBoolean(resId)
     }
 
     @DataApi class Attribute(
@@ -53,7 +53,7 @@ interface DeferredBoolean {
          *
          * @throws IllegalArgumentException if [resId] cannot be resolved to a boolean.
          */
-        override fun resolve(context: Context) = context.resolveBooleanAttribute(resId)
+        override fun resolve(context: Context): Boolean = context.resolveBooleanAttribute(resId)
 
         private fun Context.resolveBooleanAttribute(@AttrRes resId: Int): Boolean =
             resolveAttribute(resId, "boolean", reusedTypedValue, TypedValue.TYPE_INT_BOOLEAN) {

--- a/deferred-resources/src/main/java/com/backbase/deferredresources/DeferredColor.kt
+++ b/deferred-resources/src/main/java/com/backbase/deferredresources/DeferredColor.kt
@@ -35,7 +35,7 @@ interface DeferredColor {
         /**
          * Always resolves to [value], ignoring [context].
          */
-        override fun resolve(context: Context) = value
+        @ColorInt override fun resolve(context: Context): Int = value
     }
 
     /**
@@ -47,7 +47,7 @@ interface DeferredColor {
         /**
          * Resolve [resId] to a [ColorInt] with the given [context].
          */
-        override fun resolve(context: Context) = ContextCompat.getColor(context, resId)
+        @ColorInt override fun resolve(context: Context): Int = ContextCompat.getColor(context, resId)
     }
 
     /**
@@ -65,10 +65,9 @@ interface DeferredColor {
          *
          * @throws IllegalArgumentException if [resId] cannot be resolved to a color.
          */
-        override fun resolve(context: Context) = context.resolveColorAttribute(resId)
+        @ColorInt override fun resolve(context: Context): Int = context.resolveColorAttribute(resId)
 
-        @ColorInt
-        private fun Context.resolveColorAttribute(@AttrRes resId: Int): Int =
+        @ColorInt private fun Context.resolveColorAttribute(@AttrRes resId: Int): Int =
             resolveAttribute(
                 resId, "color", reusedTypedValue,
                 TypedValue.TYPE_INT_COLOR_RGB8, TypedValue.TYPE_INT_COLOR_ARGB8,

--- a/deferred-resources/src/main/java/com/backbase/deferredresources/DeferredDrawable.kt
+++ b/deferred-resources/src/main/java/com/backbase/deferredresources/DeferredDrawable.kt
@@ -25,7 +25,7 @@ interface DeferredDrawable {
         /**
          * Always resolves to [value], ignoring [context].
          */
-        override fun resolve(context: Context) = value
+        override fun resolve(context: Context): Drawable? = value
     }
 
     /**

--- a/deferred-resources/src/main/java/com/backbase/deferredresources/DeferredFormattedPlurals.kt
+++ b/deferred-resources/src/main/java/com/backbase/deferredresources/DeferredFormattedPlurals.kt
@@ -80,7 +80,7 @@ interface DeferredFormattedPlurals {
         /**
          * Resolve [resId] to a formatted string with the given [context], [quantity], and [formatArgs].
          */
-        override fun resolve(context: Context, quantity: Int, vararg formatArgs: Any) =
+        override fun resolve(context: Context, quantity: Int, vararg formatArgs: Any): String =
             context.resources.getQuantityString(resId, quantity, *formatArgs)
     }
 }

--- a/deferred-resources/src/main/java/com/backbase/deferredresources/DeferredFormattedString.kt
+++ b/deferred-resources/src/main/java/com/backbase/deferredresources/DeferredFormattedString.kt
@@ -24,7 +24,7 @@ interface DeferredFormattedString {
         /**
          * Always resolves [format] with the supplied [formatArgs] and the primary locale from [context].
          */
-        override fun resolve(context: Context, vararg formatArgs: Any) =
+        override fun resolve(context: Context, vararg formatArgs: Any): String  =
             String.format(context.primaryLocale, format, *formatArgs)
     }
 
@@ -38,6 +38,6 @@ interface DeferredFormattedString {
         /**
          * Resolve [resId] to a formatted string with the given [context] and [formatArgs].
          */
-        override fun resolve(context: Context, vararg formatArgs: Any) = context.getString(resId, *formatArgs)
+        override fun resolve(context: Context, vararg formatArgs: Any): String  = context.getString(resId, *formatArgs)
     }
 }

--- a/deferred-resources/src/main/java/com/backbase/deferredresources/DeferredInteger.kt
+++ b/deferred-resources/src/main/java/com/backbase/deferredresources/DeferredInteger.kt
@@ -23,7 +23,7 @@ interface DeferredInteger {
         /**
          * Always resolves to [value], ignoring [context].
          */
-        override fun resolve(context: Context) = value
+        override fun resolve(context: Context): Int = value
     }
 
     /**
@@ -35,6 +35,6 @@ interface DeferredInteger {
         /**
          * Resolve [resId] to an integer with the given [context].
          */
-        override fun resolve(context: Context) = context.resources.getInteger(resId)
+        override fun resolve(context: Context): Int = context.resources.getInteger(resId)
     }
 }

--- a/deferred-resources/src/main/java/com/backbase/deferredresources/DeferredPlurals.kt
+++ b/deferred-resources/src/main/java/com/backbase/deferredresources/DeferredPlurals.kt
@@ -86,7 +86,7 @@ interface DeferredPlurals {
          * @see android.content.res.Resources.getQuantityString
          * @see android.content.res.Resources.getQuantityText
          */
-        override fun resolve(context: Context, quantity: Int) = when (type) {
+        override fun resolve(context: Context, quantity: Int): CharSequence = when (type) {
             Type.STRING -> context.resources.getQuantityString(resId, quantity)
             Type.TEXT -> context.resources.getQuantityText(resId, quantity)
         }

--- a/deferred-resources/src/main/java/com/backbase/deferredresources/DeferredTypeface.kt
+++ b/deferred-resources/src/main/java/com/backbase/deferredresources/DeferredTypeface.kt
@@ -60,7 +60,7 @@ interface DeferredTypeface {
          * Resolve [id] to a typeface asynchronously with the given [context]. [fontCallback] will be triggered on the
          * [handler]'s thread. If [handler] is null, [fontCallback] will be triggered on the UI thread.
          */
-        override fun resolve(context: Context, fontCallback: ResourcesCompat.FontCallback, handler: Handler?) =
+        override fun resolve(context: Context, fontCallback: ResourcesCompat.FontCallback, handler: Handler?): Unit =
             ResourcesCompat.getFont(context, id, fontCallback, handler)
     }
 

--- a/deferred-resources/src/main/java/com/backbase/deferredresources/internal/Context.kt
+++ b/deferred-resources/src/main/java/com/backbase/deferredresources/internal/Context.kt
@@ -29,7 +29,7 @@ internal inline fun <T> Context.resolveAttribute(
     reusedTypedValue: TypedValue,
     vararg expectedTypes: Int,
     toTypeSafeResult: TypedValue.() -> T
-) : T {
+): T {
     try {
         val isResolved = theme.resolveAttribute(resId, reusedTypedValue, true)
         if (isResolved && expectedTypes.contains(reusedTypedValue.type))


### PR DESCRIPTION
Helps prevent the wrong type from being accidentally added to public API