### PR TITLE
Add Context parameter to DeferredDrawable.Resource transformations

### DIFF
--- a/deferred-resources/api/deferred-resources.api
+++ b/deferred-resources/api/deferred-resources.api
@@ -106,10 +106,10 @@ public final class com/backbase/deferredresources/DeferredDrawable$Constant : co
 
 public final class com/backbase/deferredresources/DeferredDrawable$Resource : com/backbase/deferredresources/DeferredDrawable {
 	public fun <init> (I)V
-	public fun <init> (ILkotlin/jvm/functions/Function1;)V
+	public fun <init> (ILkotlin/jvm/functions/Function2;)V
 	public fun <init> (IZ)V
-	public fun <init> (IZLkotlin/jvm/functions/Function1;)V
-	public synthetic fun <init> (IZLkotlin/jvm/functions/Function1;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun <init> (IZLkotlin/jvm/functions/Function2;)V
+	public synthetic fun <init> (IZLkotlin/jvm/functions/Function2;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public fun equals (Ljava/lang/Object;)Z
 	public fun hashCode ()I
 	public fun resolve (Landroid/content/Context;)Landroid/graphics/drawable/Drawable;

--- a/deferred-resources/src/androidTest/java/com/backbase/deferredresources/DeferredDrawableJavaTest.java
+++ b/deferred-resources/src/androidTest/java/com/backbase/deferredresources/DeferredDrawableJavaTest.java
@@ -1,0 +1,26 @@
+package com.backbase.deferredresources;
+
+import android.graphics.drawable.Drawable;
+import android.graphics.drawable.GradientDrawable;
+import com.backbase.deferredresources.test.R;
+import kotlin.Unit;
+import org.junit.Test;
+
+import static com.google.common.truth.Truth.assertThat;
+
+public class DeferredDrawableJavaTest {
+
+    @Test
+    public void resourceConstructor_withTransformationFunction_syntaxWorks() {
+        DeferredDrawable deferred = new DeferredDrawable.Resource(R.drawable.oval, drawable -> {
+            GradientDrawable gradientDrawable = (GradientDrawable) drawable;
+            gradientDrawable.setGradientRadius(0.4f);
+            return Unit.INSTANCE;
+        });
+
+        Drawable resolved = deferred.resolve(TestContext.getContext());
+        assertThat(resolved).isInstanceOf(GradientDrawable.class);
+        GradientDrawable resolvedGradient = (GradientDrawable) resolved;
+        assertThat(DeferredDrawableTest.getGradientRadiusCompat(resolvedGradient)).isEqualTo(0.4f);
+    }
+}

--- a/deferred-resources/src/androidTest/java/com/backbase/deferredresources/DeferredDrawableJavaTest.java
+++ b/deferred-resources/src/androidTest/java/com/backbase/deferredresources/DeferredDrawableJavaTest.java
@@ -12,7 +12,7 @@ public class DeferredDrawableJavaTest {
 
     @Test
     public void resourceConstructor_withTransformationFunction_syntaxWorks() {
-        DeferredDrawable deferred = new DeferredDrawable.Resource(R.drawable.oval, drawable -> {
+        DeferredDrawable deferred = new DeferredDrawable.Resource(R.drawable.oval, (drawable, context) -> {
             GradientDrawable gradientDrawable = (GradientDrawable) drawable;
             gradientDrawable.setGradientRadius(0.4f);
             return Unit.INSTANCE;

--- a/deferred-resources/src/androidTest/java/com/backbase/deferredresources/DeferredDrawableTest.kt
+++ b/deferred-resources/src/androidTest/java/com/backbase/deferredresources/DeferredDrawableTest.kt
@@ -78,14 +78,18 @@ class DeferredDrawableTest {
         assertThat(resolved.gradientRadiusCompat).isEqualTo(0.3f)
     }
 
-    private val GradientDrawable.gradientRadiusCompat: Float
-        get() = if (Build.VERSION.SDK_INT >= 21) gradientRadius else {
-            getPrivateField<Any>("mGradientState").getPrivateField("mGradientRadius")
-        }
+    internal companion object {
 
-    @Suppress("UNCHECKED_CAST")
-    private fun <T : Any> Any.getPrivateField(name: String): T =
-        javaClass.getDeclaredField(name)
-            .apply { isAccessible = true }
-            .get(this) as T
+        @JvmStatic internal val GradientDrawable.gradientRadiusCompat: Float
+            @JvmName("getGradientRadiusCompat")
+            get() = if (Build.VERSION.SDK_INT >= 21) gradientRadius else {
+                getPrivateField<Any>("mGradientState").getPrivateField("mGradientRadius")
+            }
+
+        @Suppress("UNCHECKED_CAST")
+        private fun <T : Any> Any.getPrivateField(name: String): T =
+            javaClass.getDeclaredField(name)
+                .apply { isAccessible = true }
+                .get(this) as T
+    }
 }

--- a/deferred-resources/src/main/java/com/backbase/deferredresources/DeferredDrawable.kt
+++ b/deferred-resources/src/main/java/com/backbase/deferredresources/DeferredDrawable.kt
@@ -37,7 +37,7 @@ interface DeferredDrawable {
     @DataApi class Resource @JvmOverloads constructor(
         @DrawableRes private val resId: Int,
         private val mutate: Boolean = true,
-        private val transformations: Drawable.() -> Unit = {}
+        private val transformations: Drawable.(Context) -> Unit = {}
     ) : DeferredDrawable {
 
         /**
@@ -45,7 +45,7 @@ interface DeferredDrawable {
          */
         constructor(
             @DrawableRes resId: Int,
-            transformations: Drawable.() -> Unit
+            transformations: Drawable.(Context) -> Unit
         ) : this(resId, mutate = true, transformations = transformations)
 
         /**
@@ -55,7 +55,7 @@ interface DeferredDrawable {
         override fun resolve(context: Context): Drawable? {
             val original = ContextCompat.getDrawable(context, resId)
             val drawable = if (mutate) original?.mutate() else original
-            return drawable?.apply(transformations)
+            return drawable?.apply { transformations(context) }
         }
     }
 }


### PR DESCRIPTION
Closes #26.

This is a breaking change, so it's important to get this in before 1.0.