### PR TITLE
Fetch deferred drawable from attribute resolves #40

### DIFF
--- a/deferred-resources/api/deferred-resources.api
+++ b/deferred-resources/api/deferred-resources.api
@@ -100,6 +100,18 @@ public abstract interface class com/backbase/deferredresources/DeferredDrawable 
 	public abstract fun resolve (Landroid/content/Context;)Landroid/graphics/drawable/Drawable;
 }
 
+public final class com/backbase/deferredresources/DeferredDrawable$Attribute : com/backbase/deferredresources/DeferredDrawable {
+	public fun <init> (I)V
+	public fun <init> (ILkotlin/jvm/functions/Function2;)V
+	public fun <init> (IZ)V
+	public fun <init> (IZLkotlin/jvm/functions/Function2;)V
+	public synthetic fun <init> (IZLkotlin/jvm/functions/Function2;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun equals (Ljava/lang/Object;)Z
+	public fun hashCode ()I
+	public fun resolve (Landroid/content/Context;)Landroid/graphics/drawable/Drawable;
+	public fun toString ()Ljava/lang/String;
+}
+
 public final class com/backbase/deferredresources/DeferredDrawable$Constant : com/backbase/deferredresources/DeferredDrawable {
 	public fun <init> (Landroid/graphics/drawable/Drawable;)V
 	public fun equals (Ljava/lang/Object;)Z

--- a/deferred-resources/src/androidTest/java/com/backbase/deferredresources/DeferredDrawableJavaTest.java
+++ b/deferred-resources/src/androidTest/java/com/backbase/deferredresources/DeferredDrawableJavaTest.java
@@ -2,6 +2,7 @@ package com.backbase.deferredresources;
 
 import android.graphics.drawable.Drawable;
 import android.graphics.drawable.GradientDrawable;
+import androidx.core.util.Preconditions;
 import com.backbase.deferredresources.test.R;
 import kotlin.Unit;
 import org.junit.Test;
@@ -21,6 +22,25 @@ public class DeferredDrawableJavaTest {
         Drawable resolved = deferred.resolve(TestContext.getContext());
         assertThat(resolved).isInstanceOf(GradientDrawable.class);
         GradientDrawable resolvedGradient = (GradientDrawable) resolved;
+        Preconditions.checkNotNull(resolvedGradient);
+        assertThat(DeferredDrawableTest.getGradientRadiusCompat(resolvedGradient)).isEqualTo(0.4f);
+    }
+
+    @Test
+    public void attributeConstructor_withTransformationFunction_syntaxWorks() {
+        TestContext.getContext().setTheme(R.style.TestTheme);
+
+        DeferredDrawable deferred =
+                new DeferredDrawable.Attribute(android.R.attr.homeAsUpIndicator, (drawable, context) -> {
+                    GradientDrawable gradientDrawable = (GradientDrawable) drawable;
+                    gradientDrawable.setGradientRadius(0.4f);
+                    return Unit.INSTANCE;
+                });
+
+        Drawable resolved = deferred.resolve(TestContext.getContext());
+        assertThat(resolved).isInstanceOf(GradientDrawable.class);
+        GradientDrawable resolvedGradient = (GradientDrawable) resolved;
+        Preconditions.checkNotNull(resolvedGradient);
         assertThat(DeferredDrawableTest.getGradientRadiusCompat(resolvedGradient)).isEqualTo(0.4f);
     }
 }

--- a/deferred-resources/src/androidTest/java/com/backbase/deferredresources/DeferredDrawableJavaTest.java
+++ b/deferred-resources/src/androidTest/java/com/backbase/deferredresources/DeferredDrawableJavaTest.java
@@ -37,7 +37,7 @@ public class DeferredDrawableJavaTest {
                     return Unit.INSTANCE;
                 });
 
-        Drawable resolved = deferred.resolve(TestContext.getContext());
+        Drawable resolved = deferred.resolve(TestContext.AppCompatContext(true));
         assertThat(resolved).isInstanceOf(GradientDrawable.class);
         GradientDrawable resolvedGradient = (GradientDrawable) resolved;
         Preconditions.checkNotNull(resolvedGradient);

--- a/deferred-resources/src/androidTest/java/com/backbase/deferredresources/DeferredDrawableJavaTest.java
+++ b/deferred-resources/src/androidTest/java/com/backbase/deferredresources/DeferredDrawableJavaTest.java
@@ -28,8 +28,6 @@ public class DeferredDrawableJavaTest {
 
     @Test
     public void attributeConstructor_withTransformationFunction_syntaxWorks() {
-        TestContext.getContext().setTheme(R.style.TestTheme);
-
         DeferredDrawable deferred =
                 new DeferredDrawable.Attribute(android.R.attr.homeAsUpIndicator, (drawable, context) -> {
                     GradientDrawable gradientDrawable = (GradientDrawable) drawable;

--- a/deferred-resources/src/androidTest/java/com/backbase/deferredresources/DeferredDrawableTest.kt
+++ b/deferred-resources/src/androidTest/java/com/backbase/deferredresources/DeferredDrawableTest.kt
@@ -79,7 +79,10 @@ internal class DeferredDrawableTest {
     }
 
     @Test fun attribute_withMutateFalse_resolvesWithContext() {
-        assumeFalse("XML drawable does not have correct radius on API 21", Build.VERSION.SDK_INT == 21)
+        assumeFalse(
+            "XML drawable does not have correct radius on API 21 and 22",
+            Build.VERSION.SDK_INT == 21 || Build.VERSION.SDK_INT == 22
+        )
 
         val deferred = DeferredDrawable.Attribute(android.R.attr.homeAsUpIndicator, mutate = false)
 

--- a/deferred-resources/src/androidTest/java/com/backbase/deferredresources/DeferredDrawableTest.kt
+++ b/deferred-resources/src/androidTest/java/com/backbase/deferredresources/DeferredDrawableTest.kt
@@ -81,11 +81,9 @@ internal class DeferredDrawableTest {
     @Test fun attribute_withMutateFalse_resolvesWithContext() {
         assumeFalse("XML drawable does not have correct radius on API 21", Build.VERSION.SDK_INT == 21)
 
-        context.setTheme(R.style.TestTheme)
-
         val deferred = DeferredDrawable.Attribute(android.R.attr.homeAsUpIndicator, mutate = false)
 
-        val resolved = deferred.resolve(context)
+        val resolved = deferred.resolve(AppCompatContext())
         assertThat(resolved).isInstanceOf(GradientDrawable::class.java)
         resolved as GradientDrawable
         assertThat(resolved.gradientRadiusCompat).isEqualTo(defaultOvalGradientFraction)
@@ -100,11 +98,9 @@ internal class DeferredDrawableTest {
     @Test fun attribute_withMutateTrue_resolvesWithContextAndMutates() {
         assumeFalse("XML drawable does not have correct radius on API 21", Build.VERSION.SDK_INT == 21)
 
-        context.setTheme(R.style.TestTheme)
-
         val deferred = DeferredDrawable.Attribute(android.R.attr.homeAsUpIndicator)
 
-        val resolved = deferred.resolve(context)
+        val resolved = deferred.resolve(AppCompatContext())
         assertThat(resolved).isInstanceOf(GradientDrawable::class.java)
         resolved as GradientDrawable
         assertThat(resolved.gradientRadiusCompat).isEqualTo(defaultOvalGradientFraction)
@@ -117,14 +113,12 @@ internal class DeferredDrawableTest {
     }
 
     @Test fun attribute_withTransformations_resolvesWithContextAndMutatesAndAppliesTransformation() {
-        context.setTheme(R.style.TestTheme)
-
         val deferred = DeferredDrawable.Attribute(android.R.attr.homeAsUpIndicator) {
             require(this is GradientDrawable)
             gradientRadius = 0.3f
         }
 
-        val resolved = deferred.resolve(context)
+        val resolved = deferred.resolve(AppCompatContext())
         assertThat(resolved).isInstanceOf(GradientDrawable::class.java)
         resolved as GradientDrawable
         assertThat(resolved.gradientRadiusCompat).isEqualTo(0.3f)

--- a/deferred-resources/src/androidTest/res/values/test_theme.xml
+++ b/deferred-resources/src/androidTest/res/values/test_theme.xml
@@ -5,7 +5,6 @@
     <item name="titleTextColor">@color/stateful_color_with_attr</item>
     <item name="subtitleTextColor">@color/stateful_color_without_attr</item>
     <item name="android:homeAsUpIndicator">@drawable/oval</item>
-    <item name="homeAsUpIndicator">@drawable/oval</item>
   </style>
 
   <style name="TestTheme.Light" parent="Theme.AppCompat.Light">
@@ -13,6 +12,5 @@
     <item name="titleTextColor">@color/stateful_color_with_attr</item>
     <item name="subtitleTextColor">@color/stateful_color_without_attr</item>
     <item name="android:homeAsUpIndicator">@drawable/oval</item>
-    <item name="homeAsUpIndicator">@drawable/oval</item>
   </style>
 </resources>

--- a/deferred-resources/src/androidTest/res/values/test_theme.xml
+++ b/deferred-resources/src/androidTest/res/values/test_theme.xml
@@ -4,11 +4,13 @@
     <item name="colorPrimary">#987654</item>
     <item name="titleTextColor">@color/stateful_color_with_attr</item>
     <item name="subtitleTextColor">@color/stateful_color_without_attr</item>
+    <item name="android:homeAsUpIndicator">@drawable/oval</item>
   </style>
 
   <style name="TestTheme.Light" parent="Theme.AppCompat.Light">
     <item name="colorPrimary">#987654</item>
     <item name="titleTextColor">@color/stateful_color_with_attr</item>
     <item name="subtitleTextColor">@color/stateful_color_without_attr</item>
+    <item name="android:homeAsUpIndicator">@drawable/oval</item>
   </style>
 </resources>

--- a/deferred-resources/src/androidTest/res/values/test_theme.xml
+++ b/deferred-resources/src/androidTest/res/values/test_theme.xml
@@ -5,6 +5,7 @@
     <item name="titleTextColor">@color/stateful_color_with_attr</item>
     <item name="subtitleTextColor">@color/stateful_color_without_attr</item>
     <item name="android:homeAsUpIndicator">@drawable/oval</item>
+    <item name="homeAsUpIndicator">@drawable/oval</item>
   </style>
 
   <style name="TestTheme.Light" parent="Theme.AppCompat.Light">
@@ -12,5 +13,6 @@
     <item name="titleTextColor">@color/stateful_color_with_attr</item>
     <item name="subtitleTextColor">@color/stateful_color_without_attr</item>
     <item name="android:homeAsUpIndicator">@drawable/oval</item>
+    <item name="homeAsUpIndicator">@drawable/oval</item>
   </style>
 </resources>

--- a/deferred-resources/src/main/java/com/backbase/deferredresources/DeferredDrawable.kt
+++ b/deferred-resources/src/main/java/com/backbase/deferredresources/DeferredDrawable.kt
@@ -77,9 +77,9 @@ public interface DeferredDrawable {
          * Convenience constructor that sets [mutate] to true when [transformations] are supplied.
          */
         public constructor(
-            @AttrRes attrId: Int,
+            @AttrRes resId: Int,
             transformations: Drawable.(Context) -> Unit
-        ) : this(attrId, mutate = true, transformations = transformations)
+        ) : this(resId, mutate = true, transformations = transformations)
 
         /**
          * Resolve [resId] to a [Drawable] with the given [context]. If [mutate] is true, returns the result of

--- a/deferred-resources/src/main/java/com/backbase/deferredresources/DeferredDrawable.kt
+++ b/deferred-resources/src/main/java/com/backbase/deferredresources/DeferredDrawable.kt
@@ -95,7 +95,6 @@ public interface DeferredDrawable {
                 reusedTypedValue = drawableTypeValue,
                 expectedTypes = intArrayOf(
                     TypedValue.TYPE_REFERENCE, // could be a direct reference to a drawable resource by id
-                    TypedValue.TYPE_ATTRIBUTE, // could be a reference to another attribute, e.g. myFancyIcon
                     TypedValue.TYPE_STRING // could be initially interpreted a string, e.g. "res/drawable/oval.xml"
                 )
             ) {

--- a/deferred-resources/src/main/java/com/backbase/deferredresources/DeferredDrawable.kt
+++ b/deferred-resources/src/main/java/com/backbase/deferredresources/DeferredDrawable.kt
@@ -62,13 +62,13 @@ public interface DeferredDrawable {
     }
 
     /**
-     * A wrapper for a [Drawable] [attrId]. Optionally [mutate]s each resolved Drawable. Optionally provide
+     * A wrapper for a [Drawable] [resId]. Optionally [mutate]s each resolved Drawable. Optionally provide
      * [transformations] (such as [Drawable.setTint]) to apply each time the Drawable is resolved.
      *
      * If [transformations] are supplied, [mutate] should be true.
      */
     @DataApi public class Attribute @JvmOverloads constructor(
-        @AttrRes private val attrId: Int,
+        @AttrRes private val resId: Int,
         private val mutate: Boolean = true,
         private val transformations: Drawable.(Context) -> Unit = {}
     ) : DeferredDrawable {
@@ -82,12 +82,12 @@ public interface DeferredDrawable {
         ) : this(attrId, mutate = true, transformations = transformations)
 
         /**
-         * Resolve [attrId] to a [Drawable] with the given [context]. If [mutate] is true, returns the result of
+         * Resolve [resId] to a [Drawable] with the given [context]. If [mutate] is true, returns the result of
          * [Drawable.mutate] instead of the original Drawable. Applies [transformations] before returning.
          */
         override fun resolve(context: Context): Drawable? {
             val original = AppCompatResources.getDrawable(context, TypedValue().apply {
-                context.theme.resolveAttribute(attrId, this, true)
+                context.theme.resolveAttribute(resId, this, true)
             }.resourceId)
             val drawable = if (mutate) original?.mutate() else original
             return drawable?.apply { transformations(context) }

--- a/demo/src/main/java/com/backbase/deferredresources/demo/DeferredResourceViews.kt
+++ b/demo/src/main/java/com/backbase/deferredresources/demo/DeferredResourceViews.kt
@@ -13,10 +13,12 @@ import androidx.core.view.setMargins
 import androidx.core.view.setPadding
 import androidx.core.widget.TextViewCompat
 import com.backbase.deferredresources.DeferredColor
+import com.backbase.deferredresources.DeferredDrawable
 import com.backbase.deferredresources.DeferredFormattedPlurals
 import com.backbase.deferredresources.DeferredPlurals
 import com.backbase.deferredresources.DeferredText
 import com.backbase.deferredresources.demo.databinding.ColorsBinding
+import com.backbase.deferredresources.demo.databinding.DrawablesBinding
 import com.backbase.deferredresources.demo.databinding.PluralsBinding
 import com.backbase.deferredresources.viewx.setText
 import com.google.android.material.textview.MaterialTextView
@@ -81,5 +83,24 @@ class DeferredPluralsView(context: Context) : DeferredResourceView(context) {
         few.text = plurals.resolve(context, 3)
         many.text = plurals.resolve(context, 14)
         other.text = plurals.resolve(context, 100)
+    }
+}
+
+class DeferredDrawablesView(context: Context) : DeferredResourceView(context) {
+    private val binding = DrawablesBinding.inflate(LayoutInflater.from(context), this)
+
+    fun display(deferredDrawable: DeferredDrawable.Constant, text: DeferredText) {
+        binding.constantLabel.text = text.resolve(context)
+        binding.constant.setImageDrawable(deferredDrawable.resolve(context))
+    }
+
+    fun display(deferredDrawable: DeferredDrawable.Resource, text: DeferredText) {
+        binding.resourceLabel.text = text.resolve(context)
+        binding.resource.setImageDrawable(deferredDrawable.resolve(context))
+    }
+
+    fun display(deferredDrawable: DeferredDrawable.Attribute, text: DeferredText) {
+        binding.attributeLabel.text = text.resolve(context)
+        binding.attribute.setImageDrawable(deferredDrawable.resolve(context))
     }
 }

--- a/demo/src/main/java/com/backbase/deferredresources/demo/DemoPagerAdapter.kt
+++ b/demo/src/main/java/com/backbase/deferredresources/demo/DemoPagerAdapter.kt
@@ -1,28 +1,42 @@
 package com.backbase.deferredresources.demo
 
 import android.graphics.Color
+import android.graphics.drawable.GradientDrawable
 import android.view.ViewGroup
 import android.widget.LinearLayout
 import androidx.recyclerview.widget.RecyclerView
 import com.backbase.deferredresources.DeferredColor
+import com.backbase.deferredresources.DeferredDrawable
 import com.backbase.deferredresources.DeferredFormattedPlurals
 import com.backbase.deferredresources.DeferredText
 
 class DemoPagerAdapter : RecyclerView.Adapter<DemoPagerAdapter.DeferredResourceViewHolder>() {
 
     private val formattedPluralsResource = DeferredFormattedPlurals.Resource(R.plurals.horses)
+    private val oval by lazy {
+        GradientDrawable(
+            GradientDrawable.Orientation.BL_TR,
+            intArrayOf(Color.parseColor("#00ff00"), Color.parseColor("#000fff"))
+        ).apply {
+            gradientType = GradientDrawable.RADIAL_GRADIENT
+            cornerRadius = 0.8f
+            shape = GradientDrawable.OVAL
+        }
+    }
 
     fun getPageName(position: Int): CharSequence = when (position) {
         0 -> "Colors"
         1 -> "Plurals resource"
+        2 -> "Drawables"
         else -> throw IllegalArgumentException("Position $position in adapter with size $itemCount")
     }
 
-    override fun getItemCount(): Int = 2
+    override fun getItemCount(): Int = ViewType.values().size
 
     override fun getItemViewType(position: Int): Int = when (position) {
         0 -> ViewType.COLORS.ordinal
         1 -> ViewType.PLURALS.ordinal
+        2 -> ViewType.DRAWABLES.ordinal
         else -> throw IndexOutOfBoundsException("Position $position in adapter with size $itemCount")
     }
 
@@ -30,6 +44,7 @@ class DemoPagerAdapter : RecyclerView.Adapter<DemoPagerAdapter.DeferredResourceV
         val view = when (ViewType.values()[viewType]) {
             ViewType.COLORS -> DeferredColorsView(parent.context)
             ViewType.PLURALS -> DeferredPluralsView(parent.context)
+            ViewType.DRAWABLES -> DeferredDrawablesView(parent.context)
         }.apply {
             layoutParams = LinearLayout.LayoutParams(
                 ViewGroup.LayoutParams.MATCH_PARENT,
@@ -58,6 +73,14 @@ class DemoPagerAdapter : RecyclerView.Adapter<DemoPagerAdapter.DeferredResourceV
             is DeferredPluralsView -> when (position) {
                 1 -> view.display(formattedPluralsResource)
             }
+            is DeferredDrawablesView -> {
+                view.display(DeferredDrawable.Constant(oval), DeferredText.Constant("Constant: "))
+                view.display(DeferredDrawable.Resource(R.drawable.oval), DeferredText.Constant("Resource: "))
+                view.display(
+                    DeferredDrawable.Attribute(android.R.attr.homeAsUpIndicator),
+                    DeferredText.Constant("Attribute: ")
+                )
+            }
         }
     }
 
@@ -66,6 +89,6 @@ class DemoPagerAdapter : RecyclerView.Adapter<DemoPagerAdapter.DeferredResourceV
     ) : RecyclerView.ViewHolder(root)
 
     private enum class ViewType {
-        COLORS, PLURALS
+        COLORS, PLURALS, DRAWABLES
     }
 }

--- a/demo/src/main/res/drawable/oval.xml
+++ b/demo/src/main/res/drawable/oval.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="utf-8"?><!--Used in a test that doesn't call mutate()-->
+<shape
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    android:shape="oval">
+
+  <gradient
+      android:type="radial"
+      android:gradientRadius="0.8"
+      android:startColor="#00ff00"
+      android:endColor="#000fff" />
+
+</shape>

--- a/demo/src/main/res/layout/drawables.xml
+++ b/demo/src/main/res/layout/drawables.xml
@@ -1,0 +1,60 @@
+<?xml version="1.0" encoding="utf-8"?>
+<merge
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
+
+    tools:layout_height="match_parent"
+    tools:layout_width="match_parent"
+
+    tools:parentTag="android.widget.ScrollView">
+
+  <LinearLayout
+      android:id="@+id/container"
+      android:layout_width="match_parent"
+      android:layout_height="wrap_content"
+
+      android:clipToPadding="false"
+      android:orientation="vertical"
+      android:padding="8dp">
+
+    <com.google.android.material.textview.MaterialTextView
+        android:id="@+id/constantLabel"
+        android:labelFor="@id/constant"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content" />
+
+    <ImageView
+        android:id="@+id/constant"
+        android:layout_width="40dp"
+        android:layout_height="40dp"
+        android:layout_gravity="center"
+        tools:ignore="ContentDescription" />
+
+    <com.google.android.material.textview.MaterialTextView
+        android:id="@+id/resourceLabel"
+        android:labelFor="@id/resource"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content" />
+
+    <ImageView
+        android:id="@+id/resource"
+        android:layout_width="40dp"
+        android:layout_height="40dp"
+        android:layout_gravity="center"
+        tools:ignore="ContentDescription" />
+
+    <com.google.android.material.textview.MaterialTextView
+        android:id="@+id/attributeLabel"
+        android:labelFor="@id/attribute"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content" />
+
+    <ImageView
+        android:id="@+id/attribute"
+        android:layout_width="40dp"
+        android:layout_height="40dp"
+        android:layout_gravity="center"
+        tools:ignore="ContentDescription" />
+  </LinearLayout>
+
+</merge>

--- a/demo/src/main/res/values/styles.xml
+++ b/demo/src/main/res/values/styles.xml
@@ -21,6 +21,9 @@
     <!--Remap legacy AppCompat attributes to MaterialComponent attributes-->
     <item name="colorPrimaryDark">?colorPrimaryVariant</item>
     <item name="colorAccent">?colorSecondary</item>
+
+    <item name="android:homeAsUpIndicator">@drawable/oval</item>
+    <item name="homeAsUpIndicator">@drawable/oval</item>
   </style>
 
 </resources>


### PR DESCRIPTION
Added DeferredDrawable.Attribute class, which mimics the functionality, implementation, documentation and tests of the DeferredDrawable.Resource class, with the only difference being the resolution of the drawable from an attribute instead of a drawable resource id.