### PR TITLE
Expand text-related docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,29 @@ textView.setText(viewModel.getText())
 textView.setTextColor(viewModel.getTextColor())
 ```
 
+### Text types
+
+Various types of text are supported: `DeferredText` for basic text, `DeferredFormattedString` for
+formatted text, `DeferredPlurals` for pluralized text, and `DeferredFormattedPlurals` for formatted,
+pluralized text. Additionally, it's possible to "partially resolve" these more complex text types to
+be more basic without yet having a `Context`.
+
+```kotlin
+val deferredFormattedPlurals = DeferredFormattedPlurals.Resource(R.plurals.formatted_plurals)
+
+// If you have the format args, quantity, and Context:
+val string: String = deferredFormattedPlurals.resolve(context, 5, "million")
+
+// If you have the format args and quantity, but no Context:
+val deferredText: DeferredText = deferredFormattedPlurals.withQuantityAndFormatArgs(5, "million")
+
+// If you have only the quantity:
+val deferredFormattedString: DeferredFormattedString = deferredFormattedPlurals.withQuantity(5)
+
+// If you have only the format args:
+val deferredPlurals: DeferredPlurals = deferredFormattedPlurals.withFormatArgs("million")
+```
+
 ## License
 ```
 Copyright 2020 Backbase R&D, B.V.

--- a/README.md
+++ b/README.md
@@ -73,6 +73,8 @@ val deferredFormattedString: DeferredFormattedString = deferredFormattedPlurals.
 val deferredPlurals: DeferredPlurals = deferredFormattedPlurals.withFormatArgs("million")
 ```
 
+All text-related types can eventually be converted to `DeferredText` through similar extensions.
+
 ## License
 ```
 Copyright 2020 Backbase R&D, B.V.

--- a/docs/index.md
+++ b/docs/index.md
@@ -61,6 +61,8 @@ val deferredFormattedString: DeferredFormattedString = deferredFormattedPlurals.
 val deferredPlurals: DeferredPlurals = deferredFormattedPlurals.withFormatArgs("million")
 ```
 
+All text-related types can eventually be converted to `DeferredText` through similar extensions.
+
 ## Import
 
 To use Deferred Resources, add the library as a dependency to your Android module:

--- a/docs/index.md
+++ b/docs/index.md
@@ -5,7 +5,7 @@ resource resolution (with Context). This allows the resolver (Activity, Fragment
 agnostic to the source (standard resources, attributes, or values fetched from an API), and allows
 repository/configuration layers to remain ignorant of Android's Context.
 
-## Example
+## Examples
 
 In the logic layer, declare the resource values however you like, without worrying about their
 resolution or about Context:
@@ -38,7 +38,30 @@ textView.setText(viewModel.getText())
 textView.setTextColor(viewModel.getTextColor())
 ```
 
-### Import
+### Text types
+
+Various types of text are supported: `DeferredText` for basic text, `DeferredFormattedString` for
+formatted text, `DeferredPlurals` for pluralized text, and `DeferredFormattedPlurals` for formatted,
+pluralized text. Additionally, it's possible to "partially resolve" these more complex text types to
+be more basic without yet having a `Context`.
+
+```kotlin
+val deferredFormattedPlurals = DeferredFormattedPlurals.Resource(R.plurals.formatted_plurals)
+
+// If you have the format args, quantity, and Context:
+val string: String = deferredFormattedPlurals.resolve(context, 5, "million")
+
+// If you have the format args and quantity, but no Context:
+val deferredText: DeferredText = deferredFormattedPlurals.withQuantityAndFormatArgs(5, "million")
+
+// If you have only the quantity:
+val deferredFormattedString: DeferredFormattedString = deferredFormattedPlurals.withQuantity(5)
+
+// If you have only the format args:
+val deferredPlurals: DeferredPlurals = deferredFormattedPlurals.withFormatArgs("million")
+```
+
+## Import
 
 To use Deferred Resources, add the library as a dependency to your Android module:
 


### PR DESCRIPTION
Closes #50. Adds a paragraph summarizing the different text types and conversions between them.