### PR TITLE
Kotlin 1.4.30

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -23,7 +23,7 @@ buildscript {
 
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$versions.kotlin"
         classpath 'org.jetbrains.dokka:dokka-gradle-plugin:1.4.20'
-        classpath 'org.jetbrains.kotlinx:binary-compatibility-validator:0.3.0'
+        classpath 'org.jetbrains.kotlinx:binary-compatibility-validator:0.4.0'
 
         classpath 'dev.drewhamilton.poko:poko-gradle-plugin:0.7.0'
 

--- a/build.gradle
+++ b/build.gradle
@@ -33,7 +33,22 @@ buildscript {
     repositories {
         mavenCentral()
         google()
-        jcenter()
+
+        // TODO: Remove Bintray dependencies when possible
+        maven { url 'https://dl.bintray.com/kotlin/dokka' }
+        maven { url 'https://dl.bintray.com/jetbrains/markdown' }
+    }
+
+    // TODO WORKAROUND: Remove when AGP no longer requires JCenter's trove4j
+    configurations.configureEach {
+        resolutionStrategy.eachDependency {
+            if (requested.group == 'org.jetbrains.trove4j' &&
+                requested.name == 'trove4j' &&
+                requested.version == '20160824'
+            ) {
+                useTarget('org.jetbrains.intellij.deps:trove4j:1.0.20181211')
+            }
+        }
     }
 }
 
@@ -54,7 +69,12 @@ allprojects { project ->
     repositories {
         mavenCentral()
         google()
-        jcenter()
+
+        // TODO: Remove Bintray dependencies when possible
+        maven { url 'https://dl.bintray.com/jetbrains/markdown' }
+        maven { url 'https://dl.bintray.com/korlibs/korlibs' }
+        maven { url 'https://dl.bintray.com/kotlin/dokka' }
+        maven { url 'https://dl.bintray.com/kotlin/kotlinx' }
     }
 
     project.plugins.withType(com.android.build.gradle.LibraryPlugin) {
@@ -63,6 +83,18 @@ allprojects { project ->
             variant.generateBuildConfigProvider.get().enabled = false
         }
         //endregion
+    }
+
+    // TODO WORKAROUND: Remove when AGP no longer requires JCenter's trove4j
+    configurations.configureEach {
+        resolutionStrategy.eachDependency {
+            if (requested.group == 'org.jetbrains.trove4j' &&
+                requested.name == 'trove4j' &&
+                requested.version == '20160824'
+            ) {
+                useTarget('org.jetbrains.intellij.deps:trove4j:1.0.20181211')
+            }
+        }
     }
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -14,7 +14,7 @@ buildscript {
         coroutines: 'org.jetbrains.kotlinx:kotlinx-coroutines-android:1.3.6',
         junit: 'junit:junit:4.13',
         junitAndroidX: 'androidx.test.ext:junit-ktx:1.1.2',
-        truth: 'com.google.truth:truth:1.1',
+        truth: 'com.google.truth:truth:1.1.2',
     ]
     //endregion
 

--- a/build.gradle
+++ b/build.gradle
@@ -19,7 +19,7 @@ buildscript {
     //endregion
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:4.1.1'
+        classpath 'com.android.tools.build:gradle:4.1.2'
 
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$versions.kotlin"
         classpath 'org.jetbrains.dokka:dokka-gradle-plugin:1.4.20'

--- a/build.gradle
+++ b/build.gradle
@@ -2,7 +2,7 @@ buildscript {
     //region Dependency declarations
     ext.versions = [
         jaCoCo: '0.8.4',
-        kotlin: '1.4.21',
+        kotlin: '1.4.30',
     ]
 
     ext.deps = [
@@ -25,7 +25,7 @@ buildscript {
         classpath 'org.jetbrains.dokka:dokka-gradle-plugin:1.4.20'
         classpath 'org.jetbrains.kotlinx:binary-compatibility-validator:0.3.0'
 
-        classpath 'dev.drewhamilton.extracare:extracare-gradle-plugin:0.5.0'
+        classpath 'dev.drewhamilton.poko:poko-gradle-plugin:0.7.0'
 
         classpath 'io.gitlab.arturbosch.detekt:detekt-gradle-plugin:1.15.0'
     }

--- a/deferred-resources/build.gradle
+++ b/deferred-resources/build.gradle
@@ -1,7 +1,7 @@
 apply plugin: 'com.android.library'
 apply plugin: 'org.jetbrains.kotlin.android'
 apply plugin: 'org.jetbrains.kotlin.plugin.parcelize'
-apply plugin: 'dev.drewhamilton.extracare'
+apply plugin: 'dev.drewhamilton.poko'
 
 ext {
     artifactName = 'deferred-resources'
@@ -50,6 +50,8 @@ dependencies {
     implementation(deps.coreKtx) {
         exclude group: 'androidx.lifecycle'
     }
+
+    implementation 'dev.drewhamilton.poko:poko-annotations:0.7.0-SNAPSHOT'
 
     androidTestImplementation deps.junitAndroidX
     androidTestImplementation deps.androidTestRules

--- a/deferred-resources/build.gradle
+++ b/deferred-resources/build.gradle
@@ -51,8 +51,6 @@ dependencies {
         exclude group: 'androidx.lifecycle'
     }
 
-    implementation 'dev.drewhamilton.poko:poko-annotations:0.7.0-SNAPSHOT'
-
     androidTestImplementation deps.junitAndroidX
     androidTestImplementation deps.androidTestRules
     androidTestImplementation deps.androidTestRunner

--- a/deferred-resources/src/main/java/com/backbase/deferredresources/DeferredBoolean.kt
+++ b/deferred-resources/src/main/java/com/backbase/deferredresources/DeferredBoolean.kt
@@ -6,7 +6,7 @@ import androidx.annotation.AttrRes
 import androidx.annotation.BoolRes
 import com.backbase.deferredresources.bool.ParcelableDeferredBoolean
 import com.backbase.deferredresources.internal.resolveAttribute
-import dev.drewhamilton.extracare.DataApi
+import dev.drewhamilton.poko.Poko
 import kotlinx.parcelize.IgnoredOnParcel
 import kotlinx.parcelize.Parcelize
 
@@ -24,7 +24,7 @@ public interface DeferredBoolean {
      * A wrapper for a constant boolean [value].
      */
     @Parcelize
-    @DataApi public class Constant(
+    @Poko public class Constant(
         private val value: Boolean
     ) : ParcelableDeferredBoolean {
         /**
@@ -37,7 +37,7 @@ public interface DeferredBoolean {
      * A wrapper for a [BoolRes] [resId].
      */
     @Parcelize
-    @DataApi public class Resource(
+    @Poko public class Resource(
         @BoolRes private val resId: Int
     ) : ParcelableDeferredBoolean {
         /**
@@ -47,7 +47,7 @@ public interface DeferredBoolean {
     }
 
     @Parcelize
-    @DataApi public class Attribute(
+    @Poko public class Attribute(
         @AttrRes private val resId: Int
     ) : ParcelableDeferredBoolean {
 

--- a/deferred-resources/src/main/java/com/backbase/deferredresources/DeferredColor.kt
+++ b/deferred-resources/src/main/java/com/backbase/deferredresources/DeferredColor.kt
@@ -10,7 +10,7 @@ import androidx.annotation.ColorRes
 import androidx.appcompat.content.res.AppCompatResources
 import com.backbase.deferredresources.color.ParcelableDeferredColor
 import com.backbase.deferredresources.internal.resolveAttribute
-import dev.drewhamilton.extracare.DataApi
+import dev.drewhamilton.poko.Poko
 import kotlinx.parcelize.IgnoredOnParcel
 import kotlinx.parcelize.Parcelize
 
@@ -33,7 +33,7 @@ public interface DeferredColor {
      * A wrapper for a constant color [value].
      */
     @Parcelize
-    @DataApi public class Constant(
+    @Poko public class Constant(
         @ColorInt private val value: Int
     ) : ParcelableDeferredColor {
 
@@ -57,7 +57,7 @@ public interface DeferredColor {
      * A wrapper for a [ColorRes] [resId].
      */
     @Parcelize
-    @DataApi public class Resource(
+    @Poko public class Resource(
         @ColorRes private val resId: Int
     ) : ParcelableDeferredColor {
         /**
@@ -81,7 +81,7 @@ public interface DeferredColor {
      * A wrapper for a [AttrRes] [resId] reference to a color.
      */
     @Parcelize
-    @DataApi public class Attribute(
+    @Poko public class Attribute(
         @AttrRes private val resId: Int
     ) : ParcelableDeferredColor {
 

--- a/deferred-resources/src/main/java/com/backbase/deferredresources/DeferredDimension.kt
+++ b/deferred-resources/src/main/java/com/backbase/deferredresources/DeferredDimension.kt
@@ -8,7 +8,7 @@ import androidx.annotation.Px
 import com.backbase.deferredresources.dimension.ParcelableDeferredDimension
 import com.backbase.deferredresources.internal.resolveAttribute
 import com.backbase.deferredresources.internal.toSize
-import dev.drewhamilton.extracare.DataApi
+import dev.drewhamilton.poko.Poko
 import kotlinx.parcelize.IgnoredOnParcel
 import kotlinx.parcelize.Parcelize
 
@@ -37,7 +37,7 @@ public interface DeferredDimension {
      * A wrapper for a constant integer [pxValue].
      */
     @Parcelize
-    @DataApi public class Constant(
+    @Poko public class Constant(
         @Px private val pxValue: Float
     ) : ParcelableDeferredDimension {
 
@@ -67,7 +67,7 @@ public interface DeferredDimension {
      * A wrapper for a [DimenRes] [resId].
      */
     @Parcelize
-    @DataApi public class Resource(
+    @Poko public class Resource(
         @DimenRes private val resId: Int
     ) : ParcelableDeferredDimension {
         /**
@@ -90,7 +90,7 @@ public interface DeferredDimension {
      * A wrapper for an [AttrRes] [resId] reference to a dimension.
      */
     @Parcelize
-    @DataApi public class Attribute(
+    @Poko public class Attribute(
         @AttrRes private val resId: Int
     ) : ParcelableDeferredDimension {
 

--- a/deferred-resources/src/main/java/com/backbase/deferredresources/DeferredDrawable.kt
+++ b/deferred-resources/src/main/java/com/backbase/deferredresources/DeferredDrawable.kt
@@ -7,7 +7,7 @@ import androidx.annotation.AttrRes
 import androidx.annotation.DrawableRes
 import androidx.appcompat.content.res.AppCompatResources
 import com.backbase.deferredresources.internal.resolveAttribute
-import dev.drewhamilton.extracare.DataApi
+import dev.drewhamilton.poko.Poko
 
 /**
  * A wrapper for resolving a [Drawable] on demand.
@@ -22,7 +22,7 @@ public interface DeferredDrawable {
     /**
      * A wrapper for a constant Drawable [value].
      */
-    @DataApi public class Constant(
+    @Poko public class Constant(
         private val value: Drawable?
     ) : DeferredDrawable {
         /**
@@ -37,7 +37,7 @@ public interface DeferredDrawable {
      *
      * If [transformations] are supplied, [mutate] should be true.
      */
-    @DataApi public class Resource @JvmOverloads constructor(
+    @Poko public class Resource @JvmOverloads constructor(
         @DrawableRes private val resId: Int,
         private val mutate: Boolean = true,
         private val transformations: Drawable.(Context) -> Unit = {}
@@ -68,7 +68,7 @@ public interface DeferredDrawable {
      *
      * If [transformations] are supplied, [mutate] should be true.
      */
-    @DataApi public class Attribute @JvmOverloads constructor(
+    @Poko public class Attribute @JvmOverloads constructor(
         @AttrRes private val resId: Int,
         private val mutate: Boolean = true,
         private val transformations: Drawable.(Context) -> Unit = {}

--- a/deferred-resources/src/main/java/com/backbase/deferredresources/DeferredFormattedPlurals.kt
+++ b/deferred-resources/src/main/java/com/backbase/deferredresources/DeferredFormattedPlurals.kt
@@ -6,7 +6,7 @@ import androidx.annotation.PluralsRes
 import androidx.annotation.RequiresApi
 import com.backbase.deferredresources.internal.primaryLocale
 import com.backbase.deferredresources.text.ParcelableDeferredFormattedPlurals
-import dev.drewhamilton.extracare.DataApi
+import dev.drewhamilton.poko.Poko
 import kotlinx.parcelize.Parcelize
 
 /**
@@ -24,7 +24,7 @@ public interface DeferredFormattedPlurals {
      */
     // Primary constructor is internal rather than private so the generated Creator can access it
     @Parcelize
-    @DataApi public class Constant internal constructor(
+    @Poko public class Constant internal constructor(
         private val delegate: DeferredPlurals.Constant
     ) : ParcelableDeferredFormattedPlurals {
 
@@ -70,7 +70,7 @@ public interface DeferredFormattedPlurals {
      * A wrapper for a format-able [PluralsRes] [resId].
      */
     @Parcelize
-    @DataApi public class Resource(
+    @Poko public class Resource(
         @PluralsRes private val resId: Int
     ) : ParcelableDeferredFormattedPlurals {
         /**

--- a/deferred-resources/src/main/java/com/backbase/deferredresources/DeferredFormattedString.kt
+++ b/deferred-resources/src/main/java/com/backbase/deferredresources/DeferredFormattedString.kt
@@ -4,7 +4,7 @@ import android.content.Context
 import androidx.annotation.StringRes
 import com.backbase.deferredresources.internal.primaryLocale
 import com.backbase.deferredresources.text.ParcelableDeferredFormattedString
-import dev.drewhamilton.extracare.DataApi
+import dev.drewhamilton.poko.Poko
 import kotlinx.parcelize.Parcelize
 
 /**
@@ -21,7 +21,7 @@ public interface DeferredFormattedString {
      * A wrapper for a constant format-able [format] string.
      */
     @Parcelize
-    @DataApi public class Constant(
+    @Poko public class Constant(
         private val format: String
     ) : ParcelableDeferredFormattedString {
         /**
@@ -35,7 +35,7 @@ public interface DeferredFormattedString {
      * A wrapper for a format-able [StringRes] [resId].
      */
     @Parcelize
-    @DataApi public class Resource(
+    @Poko public class Resource(
         @StringRes private val resId: Int
     ) : ParcelableDeferredFormattedString {
 

--- a/deferred-resources/src/main/java/com/backbase/deferredresources/DeferredInteger.kt
+++ b/deferred-resources/src/main/java/com/backbase/deferredresources/DeferredInteger.kt
@@ -3,7 +3,7 @@ package com.backbase.deferredresources
 import android.content.Context
 import androidx.annotation.IntegerRes
 import com.backbase.deferredresources.integer.ParcelableDeferredInteger
-import dev.drewhamilton.extracare.DataApi
+import dev.drewhamilton.poko.Poko
 import kotlinx.parcelize.Parcelize
 
 /**
@@ -20,7 +20,7 @@ public interface DeferredInteger {
      * A wrapper for a constant integer [value].
      */
     @Parcelize
-    @DataApi public class Constant(
+    @Poko public class Constant(
         private val value: Int
     ) : ParcelableDeferredInteger {
         /**
@@ -33,7 +33,7 @@ public interface DeferredInteger {
      * A wrapper for a [IntegerRes] [resId].
      */
     @Parcelize
-    @DataApi public class Resource(
+    @Poko public class Resource(
         @IntegerRes private val resId: Int
     ) : ParcelableDeferredInteger {
         /**

--- a/deferred-resources/src/main/java/com/backbase/deferredresources/DeferredIntegerArray.kt
+++ b/deferred-resources/src/main/java/com/backbase/deferredresources/DeferredIntegerArray.kt
@@ -3,7 +3,7 @@ package com.backbase.deferredresources
 import android.content.Context
 import androidx.annotation.ArrayRes
 import com.backbase.deferredresources.integer.ParcelableDeferredIntegerArray
-import dev.drewhamilton.extracare.DataApi
+import dev.drewhamilton.poko.Poko
 import kotlinx.parcelize.Parcelize
 
 /**
@@ -24,7 +24,7 @@ public interface DeferredIntegerArray {
      */
     // Primary constructor is internal rather than private so the generated Creator can access it
     @Parcelize
-    @DataApi public class Constant internal constructor(
+    @Poko public class Constant internal constructor(
         private val values: List<Int>
     ) : ParcelableDeferredIntegerArray {
 
@@ -52,7 +52,7 @@ public interface DeferredIntegerArray {
      * A wrapper for an integer [ArrayRes] [id].
      */
     @Parcelize
-    @DataApi public class Resource(
+    @Poko public class Resource(
         @ArrayRes private val id: Int
     ) : ParcelableDeferredIntegerArray {
         /**

--- a/deferred-resources/src/main/java/com/backbase/deferredresources/DeferredPlurals.kt
+++ b/deferred-resources/src/main/java/com/backbase/deferredresources/DeferredPlurals.kt
@@ -7,7 +7,7 @@ import androidx.annotation.PluralsRes
 import androidx.annotation.RequiresApi
 import com.backbase.deferredresources.internal.PluralRulesCompat
 import com.backbase.deferredresources.text.ParcelableDeferredPlurals
-import dev.drewhamilton.extracare.DataApi
+import dev.drewhamilton.poko.Poko
 import kotlinx.parcelize.Parcelize
 
 /**
@@ -26,7 +26,7 @@ public interface DeferredPlurals {
      */
     // Primary constructor is internal rather than private so the generated Creator can access it
     @Parcelize
-    @DataApi public class Constant internal constructor(
+    @Poko public class Constant internal constructor(
         private val other: CharSequence,
         private val zero: CharSequence = other,
         private val one: CharSequence = other,
@@ -89,7 +89,7 @@ public interface DeferredPlurals {
      * A wrapper for a [PluralsRes] [resId].
      */
     @Parcelize
-    @DataApi public class Resource(
+    @Poko public class Resource(
         @PluralsRes private val resId: Int,
         private val type: Type = Type.STRING
     ) : ParcelableDeferredPlurals {

--- a/deferred-resources/src/main/java/com/backbase/deferredresources/DeferredText.kt
+++ b/deferred-resources/src/main/java/com/backbase/deferredresources/DeferredText.kt
@@ -3,7 +3,7 @@ package com.backbase.deferredresources
 import android.content.Context
 import androidx.annotation.StringRes
 import com.backbase.deferredresources.text.ParcelableDeferredText
-import dev.drewhamilton.extracare.DataApi
+import dev.drewhamilton.poko.Poko
 import kotlinx.parcelize.Parcelize
 
 /**
@@ -20,7 +20,7 @@ public interface DeferredText {
      * A wrapper for a constant text [value].
      */
     @Parcelize
-    @DataApi public class Constant(
+    @Poko public class Constant(
         private val value: CharSequence
     ) : ParcelableDeferredText {
         /**
@@ -33,7 +33,7 @@ public interface DeferredText {
      * A wrapper for a text [resId].
      */
     @Parcelize
-    @DataApi public class Resource @JvmOverloads constructor(
+    @Poko public class Resource @JvmOverloads constructor(
         @StringRes private val resId: Int,
         private val type: Type = Type.STRING
     ) : ParcelableDeferredText {

--- a/deferred-resources/src/main/java/com/backbase/deferredresources/DeferredTextArray.kt
+++ b/deferred-resources/src/main/java/com/backbase/deferredresources/DeferredTextArray.kt
@@ -4,7 +4,7 @@ import android.content.Context
 import androidx.annotation.ArrayRes
 import com.backbase.deferredresources.DeferredTextArray.Resource.Type
 import com.backbase.deferredresources.text.ParcelableDeferredTextArray
-import dev.drewhamilton.extracare.DataApi
+import dev.drewhamilton.poko.Poko
 import kotlinx.parcelize.Parcelize
 
 /**
@@ -25,7 +25,7 @@ public interface DeferredTextArray {
      */
     // Primary constructor is internal rather than private so the generated Creator can access it
     @Parcelize
-    @DataApi public class Constant internal constructor(
+    @Poko public class Constant internal constructor(
         private val values: List<CharSequence>
     ) : ParcelableDeferredTextArray {
 
@@ -54,7 +54,7 @@ public interface DeferredTextArray {
      * resource.
      */
     @Parcelize
-    @DataApi public class Resource @JvmOverloads constructor(
+    @Poko public class Resource @JvmOverloads constructor(
         @ArrayRes private val id: Int,
         private val type: Type = Type.STRING
     ) : ParcelableDeferredTextArray {

--- a/deferred-resources/src/main/java/com/backbase/deferredresources/DeferredTypeface.kt
+++ b/deferred-resources/src/main/java/com/backbase/deferredresources/DeferredTypeface.kt
@@ -7,7 +7,7 @@ import androidx.annotation.FontRes
 import androidx.core.content.res.ResourcesCompat
 import androidx.core.provider.FontsContractCompat.FontRequestCallback.FAIL_REASON_FONT_NOT_FOUND
 import com.backbase.deferredresources.internal.orUiHandler
-import dev.drewhamilton.extracare.DataApi
+import dev.drewhamilton.poko.Poko
 
 /**
  * A wrapper for resolving a typeface on demand.
@@ -28,7 +28,7 @@ public interface DeferredTypeface {
     /**
      * A wrapper for a constant typeface [value].
      */
-    @DataApi public class Constant(
+    @Poko public class Constant(
         private val value: Typeface
     ) : DeferredTypeface {
         /**
@@ -48,7 +48,7 @@ public interface DeferredTypeface {
     /**
      * A wrapper for a [FontRes] [id].
      */
-    @DataApi public class Resource(
+    @Poko public class Resource(
         @FontRes private val id: Int
     ) : DeferredTypeface {
         /**
@@ -64,7 +64,7 @@ public interface DeferredTypeface {
             ResourcesCompat.getFont(context, id, fontCallback, handler)
     }
 
-    @DataApi public class Asset(
+    @Poko public class Asset(
         private val path: String
     ) : DeferredTypeface {
         /**

--- a/deferred-resources/src/main/java/com/backbase/deferredresources/color/DeferredColorWithAlpha.kt
+++ b/deferred-resources/src/main/java/com/backbase/deferredresources/color/DeferredColorWithAlpha.kt
@@ -7,7 +7,7 @@ import androidx.annotation.FloatRange
 import androidx.annotation.IntRange
 import androidx.core.graphics.ColorUtils
 import com.backbase.deferredresources.DeferredColor
-import dev.drewhamilton.extracare.DataApi
+import dev.drewhamilton.poko.Poko
 import kotlin.math.roundToInt
 import kotlinx.parcelize.Parcelize
 import kotlinx.parcelize.RawValue
@@ -32,7 +32,7 @@ public fun DeferredColor.withAlpha(@FloatRange(from = 0.0, to = 1.0) alpha: Floa
  * This class implements [android.os.Parcelable]. It will throw at runtime if [base] cannot be marshalled.
  */
 @Parcelize
-@DataApi public class DeferredColorWithAlpha(
+@Poko public class DeferredColorWithAlpha(
     private val base: @RawValue DeferredColor,
     @IntRange(from = 0x00, to = 0xFF) private val alpha: Int
 ) : ParcelableDeferredColor {

--- a/deferred-resources/src/main/java/com/backbase/deferredresources/color/SdkIntDeferredColor.kt
+++ b/deferred-resources/src/main/java/com/backbase/deferredresources/color/SdkIntDeferredColor.kt
@@ -5,7 +5,7 @@ import android.content.res.ColorStateList
 import android.os.Build
 import androidx.annotation.ColorInt
 import com.backbase.deferredresources.DeferredColor
-import dev.drewhamilton.extracare.DataApi
+import dev.drewhamilton.poko.Poko
 import kotlinx.parcelize.Parcelize
 import kotlinx.parcelize.RawValue
 
@@ -20,7 +20,7 @@ import kotlinx.parcelize.RawValue
  */
 // Primary constructor is internal rather than private so the generated Creator can access it
 @Parcelize
-@DataApi public class SdkIntDeferredColor internal constructor(
+@Poko public class SdkIntDeferredColor internal constructor(
     private val source: @RawValue DeferredColor
 ) : ParcelableDeferredColor {
 

--- a/deferred-resources/src/main/java/com/backbase/deferredresources/drawable/DeferredColorDrawable.kt
+++ b/deferred-resources/src/main/java/com/backbase/deferredresources/drawable/DeferredColorDrawable.kt
@@ -4,7 +4,7 @@ import android.content.Context
 import android.graphics.drawable.ColorDrawable
 import com.backbase.deferredresources.DeferredColor
 import com.backbase.deferredresources.DeferredDrawable
-import dev.drewhamilton.extracare.DataApi
+import dev.drewhamilton.poko.Poko
 
 /**
  * Convert a [DeferredColor] to a [DeferredDrawable] by wrapping the resolved color in a [ColorDrawable].
@@ -14,7 +14,7 @@ import dev.drewhamilton.extracare.DataApi
 /**
  * Convert a [DeferredColor] to a [DeferredDrawable] by wrapping the resolved color in a [ColorDrawable].
  */
-@DataApi public class DeferredColorDrawable(
+@Poko public class DeferredColorDrawable(
     private val deferredColor: DeferredColor
 ) : DeferredDrawable {
 

--- a/deferred-resources/src/main/java/com/backbase/deferredresources/text/FormattedDeferredPlurals.kt
+++ b/deferred-resources/src/main/java/com/backbase/deferredresources/text/FormattedDeferredPlurals.kt
@@ -3,7 +3,7 @@ package com.backbase.deferredresources.text
 import android.content.Context
 import com.backbase.deferredresources.DeferredFormattedPlurals
 import com.backbase.deferredresources.DeferredPlurals
-import dev.drewhamilton.extracare.DataApi
+import dev.drewhamilton.poko.Poko
 import kotlinx.parcelize.Parcelize
 import kotlinx.parcelize.RawValue
 
@@ -37,7 +37,7 @@ import kotlinx.parcelize.RawValue
  */
 // Primary constructor is internal rather than private so the generated Creator can access it
 @Parcelize
-@DataApi public class FormattedDeferredPlurals internal constructor(
+@Poko public class FormattedDeferredPlurals internal constructor(
     private val wrapped: @RawValue DeferredFormattedPlurals,
     private val formatArgs: @RawValue List<Any>,
 ) : ParcelableDeferredPlurals {

--- a/deferred-resources/src/main/java/com/backbase/deferredresources/text/FormattedDeferredText.kt
+++ b/deferred-resources/src/main/java/com/backbase/deferredresources/text/FormattedDeferredText.kt
@@ -3,7 +3,7 @@ package com.backbase.deferredresources.text
 import android.content.Context
 import com.backbase.deferredresources.DeferredFormattedString
 import com.backbase.deferredresources.DeferredText
-import dev.drewhamilton.extracare.DataApi
+import dev.drewhamilton.poko.Poko
 import kotlinx.parcelize.Parcelize
 import kotlinx.parcelize.RawValue
 
@@ -33,7 +33,7 @@ import kotlinx.parcelize.RawValue
  */
 // Primary constructor is internal rather than private so the generated Creator can access it
 @Parcelize
-@DataApi public class FormattedDeferredText internal constructor(
+@Poko public class FormattedDeferredText internal constructor(
     private val wrapped: @RawValue DeferredFormattedString,
     private val formatArgs: @RawValue List<Any>,
 ) : ParcelableDeferredText {

--- a/deferred-resources/src/main/java/com/backbase/deferredresources/text/QuantifiedDeferredFormattedString.kt
+++ b/deferred-resources/src/main/java/com/backbase/deferredresources/text/QuantifiedDeferredFormattedString.kt
@@ -3,7 +3,7 @@ package com.backbase.deferredresources.text
 import android.content.Context
 import com.backbase.deferredresources.DeferredFormattedPlurals
 import com.backbase.deferredresources.DeferredFormattedString
-import dev.drewhamilton.extracare.DataApi
+import dev.drewhamilton.poko.Poko
 import kotlinx.parcelize.Parcelize
 import kotlinx.parcelize.RawValue
 
@@ -35,7 +35,7 @@ import kotlinx.parcelize.RawValue
  * This class implements [android.os.Parcelable]. It will throw at runtime if [wrapped] cannot be marshalled.
  */
 @Parcelize
-@DataApi public class QuantifiedDeferredFormattedString(
+@Poko public class QuantifiedDeferredFormattedString(
     private val wrapped: @RawValue DeferredFormattedPlurals,
     private val quantity: Int
 ) : ParcelableDeferredFormattedString {

--- a/deferred-resources/src/main/java/com/backbase/deferredresources/text/QuantifiedDeferredText.kt
+++ b/deferred-resources/src/main/java/com/backbase/deferredresources/text/QuantifiedDeferredText.kt
@@ -3,7 +3,7 @@ package com.backbase.deferredresources.text
 import android.content.Context
 import com.backbase.deferredresources.DeferredPlurals
 import com.backbase.deferredresources.DeferredText
-import dev.drewhamilton.extracare.DataApi
+import dev.drewhamilton.poko.Poko
 import kotlinx.parcelize.Parcelize
 import kotlinx.parcelize.RawValue
 
@@ -31,7 +31,7 @@ import kotlinx.parcelize.RawValue
  * This class implements [android.os.Parcelable]. It will throw at runtime if [wrapped] cannot be marshalled.
  */
 @Parcelize
-@DataApi public class QuantifiedDeferredText(
+@Poko public class QuantifiedDeferredText(
     private val wrapped: @RawValue DeferredPlurals,
     private val quantity: Int
 ) : ParcelableDeferredText {

--- a/deferred-resources/src/main/java/com/backbase/deferredresources/text/QuantifiedFormattedDeferredText.kt
+++ b/deferred-resources/src/main/java/com/backbase/deferredresources/text/QuantifiedFormattedDeferredText.kt
@@ -3,7 +3,7 @@ package com.backbase.deferredresources.text
 import android.content.Context
 import com.backbase.deferredresources.DeferredFormattedPlurals
 import com.backbase.deferredresources.DeferredText
-import dev.drewhamilton.extracare.DataApi
+import dev.drewhamilton.poko.Poko
 import kotlinx.parcelize.Parcelize
 import kotlinx.parcelize.RawValue
 
@@ -44,7 +44,7 @@ import kotlinx.parcelize.RawValue
  */
 // Primary constructor is internal rather than private so the generated Creator can access it
 @Parcelize
-@DataApi public class QuantifiedFormattedDeferredText internal constructor(
+@Poko public class QuantifiedFormattedDeferredText internal constructor(
     private val wrapped: @RawValue DeferredFormattedPlurals,
     private val quantity: Int,
     private val formatArgs: @RawValue List<Any>

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.8-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.8.2-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
Along with other updates: Poko 0.7.0 (new annotations), binary compatibility validator 0.4.0, Truth 1.1.2, AGP 4.1.2, Gradle 6.8.2.

Minimizes use of JCenter to Kotlin artifacts that haven't been moved yet.