### PR TITLE
Support different units in `DeferredDimension.Constant`

### DIFF
--- a/deferred-resources/api/deferred-resources.api
+++ b/deferred-resources/api/deferred-resources.api
@@ -174,6 +174,28 @@ public class com/backbase/deferredresources/DeferredDimension$Constant$Creator :
 	public synthetic fun newArray (I)[Ljava/lang/Object;
 }
 
+public final class com/backbase/deferredresources/DeferredDimension$DpConstant : com/backbase/deferredresources/dimension/ParcelableDeferredDimension {
+	public static final field CREATOR Landroid/os/Parcelable$Creator;
+	public fun <init> (F)V
+	public fun <init> (I)V
+	public fun describeContents ()I
+	public fun equals (Ljava/lang/Object;)Z
+	public fun hashCode ()I
+	public fun resolveAsOffset (Landroid/content/Context;)I
+	public fun resolveAsSize (Landroid/content/Context;)I
+	public fun resolveExact (Landroid/content/Context;)F
+	public fun toString ()Ljava/lang/String;
+	public fun writeToParcel (Landroid/os/Parcel;I)V
+}
+
+public class com/backbase/deferredresources/DeferredDimension$DpConstant$Creator : android/os/Parcelable$Creator {
+	public fun <init> ()V
+	public final fun createFromParcel (Landroid/os/Parcel;)Lcom/backbase/deferredresources/DeferredDimension$DpConstant;
+	public synthetic fun createFromParcel (Landroid/os/Parcel;)Ljava/lang/Object;
+	public final fun newArray (I)[Lcom/backbase/deferredresources/DeferredDimension$DpConstant;
+	public synthetic fun newArray (I)[Ljava/lang/Object;
+}
+
 public final class com/backbase/deferredresources/DeferredDimension$Resource : com/backbase/deferredresources/dimension/ParcelableDeferredDimension {
 	public static final field CREATOR Landroid/os/Parcelable$Creator;
 	public fun <init> (I)V

--- a/deferred-resources/api/deferred-resources.api
+++ b/deferred-resources/api/deferred-resources.api
@@ -155,7 +155,9 @@ public class com/backbase/deferredresources/DeferredDimension$Attribute$Creator 
 public final class com/backbase/deferredresources/DeferredDimension$Constant : com/backbase/deferredresources/dimension/ParcelableDeferredDimension {
 	public static final field CREATOR Landroid/os/Parcelable$Creator;
 	public fun <init> (F)V
+	public fun <init> (FLcom/backbase/deferredresources/DeferredDimension$Constant$Unit;)V
 	public fun <init> (I)V
+	public fun <init> (ILcom/backbase/deferredresources/DeferredDimension$Constant$Unit;)V
 	public fun describeContents ()I
 	public fun equals (Ljava/lang/Object;)Z
 	public fun hashCode ()I
@@ -174,26 +176,12 @@ public class com/backbase/deferredresources/DeferredDimension$Constant$Creator :
 	public synthetic fun newArray (I)[Ljava/lang/Object;
 }
 
-public final class com/backbase/deferredresources/DeferredDimension$DpConstant : com/backbase/deferredresources/dimension/ParcelableDeferredDimension {
-	public static final field CREATOR Landroid/os/Parcelable$Creator;
-	public fun <init> (F)V
-	public fun <init> (I)V
-	public fun describeContents ()I
-	public fun equals (Ljava/lang/Object;)Z
-	public fun hashCode ()I
-	public fun resolveAsOffset (Landroid/content/Context;)I
-	public fun resolveAsSize (Landroid/content/Context;)I
-	public fun resolveExact (Landroid/content/Context;)F
-	public fun toString ()Ljava/lang/String;
-	public fun writeToParcel (Landroid/os/Parcel;I)V
-}
-
-public class com/backbase/deferredresources/DeferredDimension$DpConstant$Creator : android/os/Parcelable$Creator {
-	public fun <init> ()V
-	public final fun createFromParcel (Landroid/os/Parcel;)Lcom/backbase/deferredresources/DeferredDimension$DpConstant;
-	public synthetic fun createFromParcel (Landroid/os/Parcel;)Ljava/lang/Object;
-	public final fun newArray (I)[Lcom/backbase/deferredresources/DeferredDimension$DpConstant;
-	public synthetic fun newArray (I)[Ljava/lang/Object;
+public final class com/backbase/deferredresources/DeferredDimension$Constant$Unit : java/lang/Enum {
+	public static final field DP Lcom/backbase/deferredresources/DeferredDimension$Constant$Unit;
+	public static final field PX Lcom/backbase/deferredresources/DeferredDimension$Constant$Unit;
+	public static final field SP Lcom/backbase/deferredresources/DeferredDimension$Constant$Unit;
+	public static fun valueOf (Ljava/lang/String;)Lcom/backbase/deferredresources/DeferredDimension$Constant$Unit;
+	public static fun values ()[Lcom/backbase/deferredresources/DeferredDimension$Constant$Unit;
 }
 
 public final class com/backbase/deferredresources/DeferredDimension$Resource : com/backbase/deferredresources/dimension/ParcelableDeferredDimension {

--- a/deferred-resources/src/androidTest/java/com/backbase/deferredresources/DeferredDimensionTest.kt
+++ b/deferred-resources/src/androidTest/java/com/backbase/deferredresources/DeferredDimensionTest.kt
@@ -2,6 +2,7 @@ package com.backbase.deferredresources
 
 import androidx.annotation.Px
 import com.backbase.deferredresources.dimension.ParcelableDeferredDimension
+import com.backbase.deferredresources.internal.toSize
 import com.backbase.deferredresources.test.AppCompatContext
 import com.backbase.deferredresources.test.R
 import com.backbase.deferredresources.test.context
@@ -75,6 +76,80 @@ internal class DeferredDimensionTest {
 
     @Test fun constant_parcelsThroughBundle() {
         testParcelable<ParcelableDeferredDimension>(DeferredDimension.Constant(5.5f))
+    }
+    //endregion
+
+    //region DpConstant
+    private val density: Float
+        get() = context.resources.displayMetrics.density
+
+    @Test fun dpConstantResolveAsSize_normalPxValue_returnsRoundedValue() {
+        val dpValue = 9.6f
+        val deferred = DeferredDimension.DpConstant(dpValue)
+        assertThat(deferred.resolveAsSize(context)).isEqualTo((dpValue * density).toSize())
+    }
+
+    @Test fun dpConstantResolveAsSize_lowPxValue_returnsOne() {
+        val deferred = DeferredDimension.DpConstant(0.01f)
+        assertThat(deferred.resolveAsSize(context)).isEqualTo(1)
+    }
+
+    @Test fun dpConstantResolveAsSize_zeroPxValue_returnsZero() {
+        val deferred = DeferredDimension.DpConstant(0)
+        assertThat(deferred.resolveAsSize(context)).isEqualTo(0)
+    }
+
+    @Test fun dpConstantResolveAsSize_lowNegativePxValue_returnsNegativeOne() {
+        val deferred = DeferredDimension.DpConstant(-0.01f)
+        assertThat(deferred.resolveAsSize(context)).isEqualTo(-1)
+    }
+
+    @Test fun dpConstantResolveAsOffset_normalPxValue_returnsTruncatedValue() {
+        val dpValue = 9.6f
+        val deferred = DeferredDimension.DpConstant(dpValue)
+        assertThat(deferred.resolveAsOffset(context)).isEqualTo((dpValue * density).toInt())
+    }
+
+    @Test fun dpConstantResolveAsOffset_lowPxValue_returnsZero() {
+        val deferred = DeferredDimension.DpConstant(0.03f)
+        assertThat(deferred.resolveAsOffset(context)).isEqualTo(0)
+    }
+
+    @Test fun dpConstantResolveAsOffset_zeroPxValue_returnsZero() {
+        val deferred = DeferredDimension.DpConstant(0)
+        assertThat(deferred.resolveAsOffset(context)).isEqualTo(0)
+    }
+
+    @Test fun dpConstantResolveAsOffset_lowNegativePxValue_returnsZero() {
+        val deferred = DeferredDimension.DpConstant(-0.049f)
+        assertThat(deferred.resolveAsOffset(context)).isEqualTo(0)
+    }
+
+    @Test fun dpConstantResolveExact_normalPxValue_returnsExactValue() {
+        val dpValue = 9.6f
+        val deferred = DeferredDimension.DpConstant(dpValue)
+        assertThat(deferred.resolveExact(context)).isEqualTo(dpValue * density)
+    }
+
+    @Test fun dpConstantResolveExact_lowPxValue_returnsExactValue() {
+        val dpValue = 0.03f
+        val deferred = DeferredDimension.DpConstant(dpValue)
+        assertThat(deferred.resolveExact(context)).isEqualTo(dpValue * density)
+    }
+
+    @Test fun dpConstantResolveExact_zeroPxValue_returnsExactValue() {
+        val deferred = DeferredDimension.DpConstant(0)
+        assertThat(deferred.resolveExact(context)).isEqualTo(0f)
+    }
+
+    @Test fun dpConstantResolveExact_lowNegativePxValue_returnsExactValue() {
+        val dpValue = -0.049f
+        val deferred = DeferredDimension.DpConstant(dpValue)
+        assertThat(deferred.resolveExact(context)).isEqualTo(dpValue * density)
+    }
+
+    @Test fun dpConstant_parcelsThroughBundle() {
+        testParcelable<ParcelableDeferredDimension>(DeferredDimension.DpConstant(7.7f))
     }
     //endregion
 

--- a/deferred-resources/src/androidTest/java/com/backbase/deferredresources/DeferredDimensionTest.kt
+++ b/deferred-resources/src/androidTest/java/com/backbase/deferredresources/DeferredDimensionTest.kt
@@ -14,6 +14,8 @@ import org.junit.Test
 internal class DeferredDimensionTest {
 
     //region Constant
+
+    //region PX
     @Test fun constantResolveAsSize_normalPxValue_returnsRoundedValue() {
         val deferred = DeferredDimension.Constant(9.6f)
         assertThat(deferred.resolveAsSize(context)).isEqualTo(10)
@@ -74,83 +76,163 @@ internal class DeferredDimensionTest {
         assertThat(deferred.resolveExact(context)).isEqualTo(-0.49f)
     }
 
-    @Test fun constant_parcelsThroughBundle() {
+    @Test fun constant_parcels() {
         testParcelable<ParcelableDeferredDimension>(DeferredDimension.Constant(5.5f))
     }
     //endregion
 
-    //region DpConstant
+    //region DP
     private val density: Float
         get() = context.resources.displayMetrics.density
 
-    @Test fun dpConstantResolveAsSize_normalDpValue_returnsRoundedValue() {
+    @Test fun constantResolveAsSize_normalDpValue_returnsRoundedValue() {
         val dpValue = 9.6f
-        val deferred = DeferredDimension.DpConstant(dpValue)
-        assertThat(deferred.resolveAsSize(context)).isEqualTo((dpValue * density).toSize())
+        val deferred = DeferredDimension.Constant(dpValue, DeferredDimension.Constant.Unit.DP)
+        assertThat(deferred.resolveAsSize(context)).isEqualTo((dpValue * scaledDensity).toSize())
     }
 
-    @Test fun dpConstantResolveAsSize_lowDpValue_returnsOne() {
-        val deferred = DeferredDimension.DpConstant(0.01f)
+    @Test fun constantResolveAsSize_lowDpValue_returnsOne() {
+        val deferred = DeferredDimension.Constant(0.01f, DeferredDimension.Constant.Unit.DP)
         assertThat(deferred.resolveAsSize(context)).isEqualTo(1)
     }
 
-    @Test fun dpConstantResolveAsSize_zeroDpValue_returnsZero() {
-        val deferred = DeferredDimension.DpConstant(0)
+    @Test fun constantResolveAsSize_zeroDpValue_returnsZero() {
+        val deferred = DeferredDimension.Constant(0, DeferredDimension.Constant.Unit.DP)
         assertThat(deferred.resolveAsSize(context)).isEqualTo(0)
     }
 
-    @Test fun dpConstantResolveAsSize_lowNegativeDpValue_returnsNegativeOne() {
-        val deferred = DeferredDimension.DpConstant(-0.01f)
+    @Test fun constantResolveAsSize_lowNegativeDpValue_returnsNegativeOne() {
+        val deferred = DeferredDimension.Constant(-0.01f, DeferredDimension.Constant.Unit.DP)
         assertThat(deferred.resolveAsSize(context)).isEqualTo(-1)
     }
 
-    @Test fun dpConstantResolveAsOffset_normalDpValue_returnsTruncatedValue() {
+    @Test fun constantResolveAsOffset_normalDpValue_returnsTruncatedValue() {
         val dpValue = 9.6f
-        val deferred = DeferredDimension.DpConstant(dpValue)
-        assertThat(deferred.resolveAsOffset(context)).isEqualTo((dpValue * density).toInt())
+        val deferred = DeferredDimension.Constant(dpValue, DeferredDimension.Constant.Unit.DP)
+        assertThat(deferred.resolveAsOffset(context)).isEqualTo((dpValue * scaledDensity).toInt())
     }
 
-    @Test fun dpConstantResolveAsOffset_lowDpValue_returnsZero() {
-        val deferred = DeferredDimension.DpConstant(0.03f)
+    @Test fun constantResolveAsOffset_lowDpValue_returnsZero() {
+        val deferred = DeferredDimension.Constant(0.03f, DeferredDimension.Constant.Unit.DP)
         assertThat(deferred.resolveAsOffset(context)).isEqualTo(0)
     }
 
-    @Test fun dpConstantResolveAsOffset_zeroDpValue_returnsZero() {
-        val deferred = DeferredDimension.DpConstant(0)
+    @Test fun constantResolveAsOffset_zeroDpValue_returnsZero() {
+        val deferred = DeferredDimension.Constant(0, DeferredDimension.Constant.Unit.DP)
         assertThat(deferred.resolveAsOffset(context)).isEqualTo(0)
     }
 
-    @Test fun dpConstantResolveAsOffset_lowNegativeDpValue_returnsZero() {
-        val deferred = DeferredDimension.DpConstant(-0.049f)
+    @Test fun constantResolveAsOffset_lowNegativeDpValue_returnsZero() {
+        val deferred = DeferredDimension.Constant(-0.049f, DeferredDimension.Constant.Unit.DP)
         assertThat(deferred.resolveAsOffset(context)).isEqualTo(0)
     }
 
-    @Test fun dpConstantResolveExact_normalDpValue_returnsExactValue() {
+    @Test fun constantResolveExact_normalDpValue_returnsExactValue() {
         val dpValue = 9.6f
-        val deferred = DeferredDimension.DpConstant(dpValue)
-        assertThat(deferred.resolveExact(context)).isEqualTo(dpValue * density)
+        val deferred = DeferredDimension.Constant(dpValue, DeferredDimension.Constant.Unit.DP)
+        assertThat(deferred.resolveExact(context)).isEqualTo(dpValue * scaledDensity)
     }
 
-    @Test fun dpConstantResolveExact_lowDpValue_returnsExactValue() {
+    @Test fun constantResolveExact_lowDpValue_returnsExactValue() {
         val dpValue = 0.03f
-        val deferred = DeferredDimension.DpConstant(dpValue)
-        assertThat(deferred.resolveExact(context)).isEqualTo(dpValue * density)
+        val deferred = DeferredDimension.Constant(dpValue, DeferredDimension.Constant.Unit.DP)
+        assertThat(deferred.resolveExact(context)).isEqualTo(dpValue * scaledDensity)
     }
 
-    @Test fun dpConstantResolveExact_zeroDpValue_returnsExactValue() {
-        val deferred = DeferredDimension.DpConstant(0)
+    @Test fun constantResolveExact_zeroDpValue_returnsExactValue() {
+        val deferred = DeferredDimension.Constant(0, DeferredDimension.Constant.Unit.DP)
         assertThat(deferred.resolveExact(context)).isEqualTo(0f)
     }
 
-    @Test fun dpConstantResolveExact_lowNegativeDpValue_returnsExactValue() {
+    @Test fun constantResolveExact_lowNegativeDpValue_returnsExactValue() {
         val dpValue = -0.049f
-        val deferred = DeferredDimension.DpConstant(dpValue)
-        assertThat(deferred.resolveExact(context)).isEqualTo(dpValue * density)
+        val deferred = DeferredDimension.Constant(dpValue, DeferredDimension.Constant.Unit.DP)
+        assertThat(deferred.resolveExact(context)).isEqualTo(dpValue * scaledDensity)
     }
 
-    @Test fun dpConstant_parcels() {
-        testParcelable<ParcelableDeferredDimension>(DeferredDimension.DpConstant(7.7f))
+    @Test fun constant_dp_parcels() {
+        testParcelable<ParcelableDeferredDimension>(
+            DeferredDimension.Constant(7.7f, DeferredDimension.Constant.Unit.DP)
+        )
     }
+    //endregion
+
+    //region SP
+    private val scaledDensity: Float
+        get() = context.resources.displayMetrics.scaledDensity
+
+    @Test fun constantResolveAsSize_normalSpValue_returnsRoundedValue() {
+        val dpValue = 9.6f
+        val deferred = DeferredDimension.Constant(dpValue, DeferredDimension.Constant.Unit.SP)
+        assertThat(deferred.resolveAsSize(context)).isEqualTo((dpValue * scaledDensity).toSize())
+    }
+
+    @Test fun constantResolveAsSize_lowSpValue_returnsOne() {
+        val deferred = DeferredDimension.Constant(0.01f, DeferredDimension.Constant.Unit.SP)
+        assertThat(deferred.resolveAsSize(context)).isEqualTo(1)
+    }
+
+    @Test fun constantResolveAsSize_zeroSpValue_returnsZero() {
+        val deferred = DeferredDimension.Constant(0, DeferredDimension.Constant.Unit.SP)
+        assertThat(deferred.resolveAsSize(context)).isEqualTo(0)
+    }
+
+    @Test fun constantResolveAsSize_lowNegativeSpValue_returnsNegativeOne() {
+        val deferred = DeferredDimension.Constant(-0.01f, DeferredDimension.Constant.Unit.SP)
+        assertThat(deferred.resolveAsSize(context)).isEqualTo(-1)
+    }
+
+    @Test fun constantResolveAsOffset_normalSpValue_returnsTruncatedValue() {
+        val dpValue = 9.6f
+        val deferred = DeferredDimension.Constant(dpValue, DeferredDimension.Constant.Unit.SP)
+        assertThat(deferred.resolveAsOffset(context)).isEqualTo((dpValue * scaledDensity).toInt())
+    }
+
+    @Test fun constantResolveAsOffset_lowSpValue_returnsZero() {
+        val deferred = DeferredDimension.Constant(0.03f, DeferredDimension.Constant.Unit.SP)
+        assertThat(deferred.resolveAsOffset(context)).isEqualTo(0)
+    }
+
+    @Test fun constantResolveAsOffset_zeroSpValue_returnsZero() {
+        val deferred = DeferredDimension.Constant(0, DeferredDimension.Constant.Unit.SP)
+        assertThat(deferred.resolveAsOffset(context)).isEqualTo(0)
+    }
+
+    @Test fun constantResolveAsOffset_lowNegativeSpValue_returnsZero() {
+        val deferred = DeferredDimension.Constant(-0.049f, DeferredDimension.Constant.Unit.SP)
+        assertThat(deferred.resolveAsOffset(context)).isEqualTo(0)
+    }
+
+    @Test fun constantResolveExact_normalSpValue_returnsExactValue() {
+        val dpValue = 9.6f
+        val deferred = DeferredDimension.Constant(dpValue, DeferredDimension.Constant.Unit.SP)
+        assertThat(deferred.resolveExact(context)).isEqualTo(dpValue * scaledDensity)
+    }
+
+    @Test fun constantResolveExact_lowSpValue_returnsExactValue() {
+        val dpValue = 0.03f
+        val deferred = DeferredDimension.Constant(dpValue, DeferredDimension.Constant.Unit.SP)
+        assertThat(deferred.resolveExact(context)).isEqualTo(dpValue * scaledDensity)
+    }
+
+    @Test fun constantResolveExact_zeroSpValue_returnsExactValue() {
+        val deferred = DeferredDimension.Constant(0, DeferredDimension.Constant.Unit.SP)
+        assertThat(deferred.resolveExact(context)).isEqualTo(0f)
+    }
+
+    @Test fun constantResolveExact_lowNegativeSpValue_returnsExactValue() {
+        val dpValue = -0.049f
+        val deferred = DeferredDimension.Constant(dpValue, DeferredDimension.Constant.Unit.SP)
+        assertThat(deferred.resolveExact(context)).isEqualTo(dpValue * scaledDensity)
+    }
+
+    @Test fun constant_sp_parcels() {
+        testParcelable<ParcelableDeferredDimension>(
+            DeferredDimension.Constant(9.9f, DeferredDimension.Constant.Unit.SP)
+        )
+    }
+    //endregion
+
     //endregion
 
     //region Resource

--- a/deferred-resources/src/androidTest/java/com/backbase/deferredresources/DeferredDimensionTest.kt
+++ b/deferred-resources/src/androidTest/java/com/backbase/deferredresources/DeferredDimensionTest.kt
@@ -83,72 +83,72 @@ internal class DeferredDimensionTest {
     private val density: Float
         get() = context.resources.displayMetrics.density
 
-    @Test fun dpConstantResolveAsSize_normalPxValue_returnsRoundedValue() {
+    @Test fun dpConstantResolveAsSize_normalDpValue_returnsRoundedValue() {
         val dpValue = 9.6f
         val deferred = DeferredDimension.DpConstant(dpValue)
         assertThat(deferred.resolveAsSize(context)).isEqualTo((dpValue * density).toSize())
     }
 
-    @Test fun dpConstantResolveAsSize_lowPxValue_returnsOne() {
+    @Test fun dpConstantResolveAsSize_lowDpValue_returnsOne() {
         val deferred = DeferredDimension.DpConstant(0.01f)
         assertThat(deferred.resolveAsSize(context)).isEqualTo(1)
     }
 
-    @Test fun dpConstantResolveAsSize_zeroPxValue_returnsZero() {
+    @Test fun dpConstantResolveAsSize_zeroDpValue_returnsZero() {
         val deferred = DeferredDimension.DpConstant(0)
         assertThat(deferred.resolveAsSize(context)).isEqualTo(0)
     }
 
-    @Test fun dpConstantResolveAsSize_lowNegativePxValue_returnsNegativeOne() {
+    @Test fun dpConstantResolveAsSize_lowNegativeDpValue_returnsNegativeOne() {
         val deferred = DeferredDimension.DpConstant(-0.01f)
         assertThat(deferred.resolveAsSize(context)).isEqualTo(-1)
     }
 
-    @Test fun dpConstantResolveAsOffset_normalPxValue_returnsTruncatedValue() {
+    @Test fun dpConstantResolveAsOffset_normalDpValue_returnsTruncatedValue() {
         val dpValue = 9.6f
         val deferred = DeferredDimension.DpConstant(dpValue)
         assertThat(deferred.resolveAsOffset(context)).isEqualTo((dpValue * density).toInt())
     }
 
-    @Test fun dpConstantResolveAsOffset_lowPxValue_returnsZero() {
+    @Test fun dpConstantResolveAsOffset_lowDpValue_returnsZero() {
         val deferred = DeferredDimension.DpConstant(0.03f)
         assertThat(deferred.resolveAsOffset(context)).isEqualTo(0)
     }
 
-    @Test fun dpConstantResolveAsOffset_zeroPxValue_returnsZero() {
+    @Test fun dpConstantResolveAsOffset_zeroDpValue_returnsZero() {
         val deferred = DeferredDimension.DpConstant(0)
         assertThat(deferred.resolveAsOffset(context)).isEqualTo(0)
     }
 
-    @Test fun dpConstantResolveAsOffset_lowNegativePxValue_returnsZero() {
+    @Test fun dpConstantResolveAsOffset_lowNegativeDpValue_returnsZero() {
         val deferred = DeferredDimension.DpConstant(-0.049f)
         assertThat(deferred.resolveAsOffset(context)).isEqualTo(0)
     }
 
-    @Test fun dpConstantResolveExact_normalPxValue_returnsExactValue() {
+    @Test fun dpConstantResolveExact_normalDpValue_returnsExactValue() {
         val dpValue = 9.6f
         val deferred = DeferredDimension.DpConstant(dpValue)
         assertThat(deferred.resolveExact(context)).isEqualTo(dpValue * density)
     }
 
-    @Test fun dpConstantResolveExact_lowPxValue_returnsExactValue() {
+    @Test fun dpConstantResolveExact_lowDpValue_returnsExactValue() {
         val dpValue = 0.03f
         val deferred = DeferredDimension.DpConstant(dpValue)
         assertThat(deferred.resolveExact(context)).isEqualTo(dpValue * density)
     }
 
-    @Test fun dpConstantResolveExact_zeroPxValue_returnsExactValue() {
+    @Test fun dpConstantResolveExact_zeroDpValue_returnsExactValue() {
         val deferred = DeferredDimension.DpConstant(0)
         assertThat(deferred.resolveExact(context)).isEqualTo(0f)
     }
 
-    @Test fun dpConstantResolveExact_lowNegativePxValue_returnsExactValue() {
+    @Test fun dpConstantResolveExact_lowNegativeDpValue_returnsExactValue() {
         val dpValue = -0.049f
         val deferred = DeferredDimension.DpConstant(dpValue)
         assertThat(deferred.resolveExact(context)).isEqualTo(dpValue * density)
     }
 
-    @Test fun dpConstant_parcelsThroughBundle() {
+    @Test fun dpConstant_parcels() {
         testParcelable<ParcelableDeferredDimension>(DeferredDimension.DpConstant(7.7f))
     }
     //endregion

--- a/deferred-resources/src/main/java/com/backbase/deferredresources/DeferredDimension.kt
+++ b/deferred-resources/src/main/java/com/backbase/deferredresources/DeferredDimension.kt
@@ -6,6 +6,7 @@ import androidx.annotation.AttrRes
 import androidx.annotation.DimenRes
 import androidx.annotation.Dimension
 import androidx.annotation.Px
+import com.backbase.deferredresources.DeferredDimension.Constant.Unit
 import com.backbase.deferredresources.dimension.ParcelableDeferredDimension
 import com.backbase.deferredresources.internal.resolveAttribute
 import com.backbase.deferredresources.internal.toSize
@@ -35,94 +36,58 @@ public interface DeferredDimension {
     @Px public fun resolveExact(context: Context): Float
 
     /**
-     * A wrapper for a constant [pxValue].
+     * A wrapper for a constant dimension [value]. If the given [unit] is [Unit.DP] or [Unit.SP], the resolved pixel
+     * value will depend on the [Context] used to resolve it.
      */
     @Parcelize
     @Poko public class Constant(
-        @Px internal val pxValue: Float
+        @Dimension private val value: Float,
+        private val unit: Unit,
     ) : ParcelableDeferredDimension {
 
         /**
-         * Convenience for initializing with an integer [pxValue].
+         * Convenience for initializing with an integer [value] of the given [unit].
+         */
+        public constructor(@Dimension value: Int, unit: Unit) : this(value.toFloat(), unit)
+
+        /**
+         * Convenience for initializing with a [pxValue] of [Unit.PX].
+         */
+        public constructor(@Px pxValue: Float) : this(pxValue, Unit.PX)
+
+        /**
+         * Convenience for initializing with an integer [pxValue] of [Unit.PX].
          */
         public constructor(@Px pxValue: Int) : this(pxValue.toFloat())
 
         /**
-         * Rounds [pxValue] to an integer. If [pxValue] is non-zero but rounds to zero, returns 1 pixel. [context] is
-         * ignored.
+         * Rounds the resolved pixel value to an integer. If the pixel value is non-zero but rounds to zero, returns 1
+         * pixel. [context] is used to convert the original DP or SP value to pixels.
          */
-        @Px override fun resolveAsSize(context: Context): Int = pxValue.toSize()
+        @Px override fun resolveAsSize(context: Context): Int = pxValue(context).toSize()
 
         /**
-         * Truncates [pxValue] to an integer pixel value. [context] is ignored.
+         * Truncates the resolved pixel value to an integer. [context] is used to convert the original DP or SP value to
+         * pixels.
          */
-        @Px override fun resolveAsOffset(context: Context): Int = pxValue.toInt()
+        @Px override fun resolveAsOffset(context: Context): Int = pxValue(context).toInt()
 
         /**
-         * Returns [pxValue]. [context] is ignored.
+         * Returns the exact resolved pixel value. [context] is used to convert the original DP or SP value to pixels.
          */
-        @Px override fun resolveExact(context: Context): Float = pxValue
-    }
+        @Px override fun resolveExact(context: Context): Float = pxValue(context)
 
-    /**
-     * A wrapper for a constant integer [dpValue]. The given DP value can be resolved to different [Px] values depending
-     * on the Context.
-     */
-    @Parcelize
-    @Poko public class DpConstant(
-        @Dimension(unit = Dimension.DP) private val dpValue: Float
-    ) : ParcelableDeferredDimension {
+        private fun pxValue(context: Context) = value * unit.multiplier(context)
 
-        /**
-         * Convenience for initializing with an integer [dpValue].
-         */
-        public constructor(@Dimension(unit = Dimension.DP) dpValue: Int) : this(dpValue.toFloat())
+        public enum class Unit {
+            PX, DP, SP;
 
-        /**
-         * Converts the constant DP value to PX and rounds the resulting PX value to an integer. If the PX value is
-         * non-zero but rounds to zero, returns 1 pixel.
-         */
-        @Px override fun resolveAsSize(context: Context): Int =
-            getPxConstant(context).resolveAsSize(context)
-
-        /**
-         * Truncates [dpValue] to an integer pixel value. [context] is ignored.
-         */
-        @Px override fun resolveAsOffset(context: Context): Int =
-            getPxConstant(context).resolveAsOffset(context)
-
-        /**
-         * Returns [dpValue]. [context] is ignored.
-         */
-        @Px override fun resolveExact(context: Context): Float = getPxConstant(context).resolveExact(context)
-
-        /**
-         * The instance of [Constant] that resolve calls are forwarded to after DP is converted to PX. Reused when
-         * possible to avoid creating new objects too often.
-         */
-        @IgnoredOnParcel private var reusedPxConstant: Constant? = null
-
-        /**
-         * Ensures new instances of [Constant] are only created if the calculated pixel value changes. Otherwise,
-         * returns the same instance of [Constant].
-         */
-        private fun getPxConstant(context: Context): Constant {
-            @Px val calculatedPxValue = calculatePx(context)
-
-            val localPxConstant = reusedPxConstant
-            return if (calculatedPxValue == localPxConstant?.pxValue) {
-                localPxConstant
-            } else {
-                Constant(calculatedPxValue).also {
-                    reusedPxConstant = it
-                }
+            internal fun multiplier(context: Context): Float = when (this) {
+                PX -> 1f
+                DP -> context.resources.displayMetrics.density
+                SP -> context.resources.displayMetrics.scaledDensity
             }
         }
-
-        /**
-         * Convert [dpValue] to a [Px] value.
-         */
-        @Px private fun calculatePx(context: Context): Float = dpValue * context.resources.displayMetrics.density
     }
 
     /**

--- a/deferred-resources/src/main/java/com/backbase/deferredresources/DeferredDimension.kt
+++ b/deferred-resources/src/main/java/com/backbase/deferredresources/DeferredDimension.kt
@@ -77,16 +77,25 @@ public interface DeferredDimension {
          */
         @Px override fun resolveExact(context: Context): Float = pxValue(context)
 
-        private fun pxValue(context: Context) = value * unit.multiplier(context)
+        /**
+         * Convert [value] to a pixel value based on the [unit] and the given [context].
+         */
+        private fun pxValue(context: Context) = value * unit.scale(context)
 
+        /**
+         * Get the scale by which a value of a specific [Unit] should be multiplied to produce a pixel value.
+         */
+        private fun Unit.scale(context: Context): Float = when (this) {
+            Unit.PX -> 1f
+            Unit.DP -> context.resources.displayMetrics.density
+            Unit.SP -> context.resources.displayMetrics.scaledDensity
+        }
+
+        /**
+         * The measurement unit of the constant dimension value.
+         */
         public enum class Unit {
             PX, DP, SP;
-
-            internal fun multiplier(context: Context): Float = when (this) {
-                PX -> 1f
-                DP -> context.resources.displayMetrics.density
-                SP -> context.resources.displayMetrics.scaledDensity
-            }
         }
     }
 


### PR DESCRIPTION
With this PR, `DeferredDimension.Constant` adds a new `unit` parameter, so an instance can be constructed as a constant DP or SP value (in addition to the existing default, PX).