### PR TITLE
Dokka 1.4.32

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -31,18 +31,6 @@ buildscript {
         mavenCentral()
         google()
     }
-
-    // TODO WORKAROUND: Remove when AGP no longer requires JCenter's trove4j
-    configurations.configureEach {
-        resolutionStrategy.eachDependency {
-            if (requested.group == 'org.jetbrains.trove4j' &&
-                requested.name == 'trove4j' &&
-                requested.version == '20160824'
-            ) {
-                useTarget('org.jetbrains.intellij.deps:trove4j:1.0.20181211')
-            }
-        }
-    }
 }
 
 ext {
@@ -73,18 +61,6 @@ allprojects { project ->
             variant.generateBuildConfigProvider.get().enabled = false
         }
         //endregion
-    }
-
-    // TODO WORKAROUND: Remove when AGP no longer requires JCenter's trove4j
-    configurations.configureEach {
-        resolutionStrategy.eachDependency {
-            if (requested.group == 'org.jetbrains.trove4j' &&
-                requested.name == 'trove4j' &&
-                requested.version == '20160824'
-            ) {
-                useTarget('org.jetbrains.intellij.deps:trove4j:1.0.20181211')
-            }
-        }
     }
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -30,10 +30,6 @@ buildscript {
     repositories {
         mavenCentral()
         google()
-
-        // TODO: Remove Bintray dependencies when possible
-        maven { url 'https://dl.bintray.com/kotlin/dokka' }
-        maven { url 'https://dl.bintray.com/jetbrains/markdown' }
     }
 
     // TODO WORKAROUND: Remove when AGP no longer requires JCenter's trove4j
@@ -67,11 +63,8 @@ allprojects { project ->
         mavenCentral()
         google()
 
-        // TODO: Remove Bintray dependencies when possible
-        maven { url 'https://dl.bintray.com/jetbrains/markdown' }
-        maven { url 'https://dl.bintray.com/korlibs/korlibs' }
-        maven { url 'https://dl.bintray.com/kotlin/dokka' }
-        maven { url 'https://dl.bintray.com/kotlin/kotlinx' }
+        // Transitive kotlinx-html-jvm dependency for Dokka:
+        maven { url = "https://maven.pkg.jetbrains.space/public/p/kotlinx-html/maven" }
     }
 
     project.plugins.withType(com.android.build.gradle.LibraryPlugin) {

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -11,7 +11,7 @@ androidx-junit = { module = "androidx.test.ext:junit-ktx", version = "1.1.2" }
 androidx-test-rules = { module = "androidx.test:rules", version.ref = "android-test" }
 androidx-test-runner = { module = "androidx.test:runner", version.ref = "android-test" }
 detekt-gradlePlugin = { module = "io.gitlab.arturbosch.detekt:detekt-gradle-plugin", version = "1.15.0" }
-dokka-gradlePlugin = { module = "org.jetbrains.dokka:dokka-gradle-plugin", version = "1.4.20" }
+dokka-gradlePlugin = { module = "org.jetbrains.dokka:dokka-gradle-plugin", version = "1.4.32" }
 junit = { module = "junit:junit", version = "4.13" }
 kotlin-gradlePlugin = { module = "org.jetbrains.kotlin:kotlin-gradle-plugin", version.ref = "kotlin" }
 kotlinx-binaryCompatibilityValidator = { module = "org.jetbrains.kotlinx:binary-compatibility-validator", version = "0.5.0" }


### PR DESCRIPTION
Also removes all JCenter workarounds – now using Maven Central, Google, and JetBrains repositories only