### PR TITLE
Support styled `AnnotatedString` resolution in Compose

### DIFF
--- a/deferred-resources-compose-adapter/build.gradle
+++ b/deferred-resources-compose-adapter/build.gradle
@@ -83,4 +83,5 @@ dependencies {
 
     androidTestImplementation(libs.androidx.compose.material)
     androidTestImplementation(libs.androidx.compose.uiTest)
+    androidTestImplementation(project(":demo-core"))
 }

--- a/deferred-resources-compose-adapter/build.gradle
+++ b/deferred-resources-compose-adapter/build.gradle
@@ -83,5 +83,6 @@ dependencies {
 
     androidTestImplementation(libs.androidx.compose.material)
     androidTestImplementation(libs.androidx.compose.uiTest)
+    androidTestImplementation(libs.truth)
     androidTestImplementation(project(":demo-core"))
 }

--- a/deferred-resources-compose-adapter/src/androidTest/java/com/backbase/deferredresources/compose/DeferredTextAdapterTest.kt
+++ b/deferred-resources-compose-adapter/src/androidTest/java/com/backbase/deferredresources/compose/DeferredTextAdapterTest.kt
@@ -16,11 +16,19 @@
 
 package com.backbase.deferredresources.compose
 
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.text.AnnotatedString
 import androidx.compose.ui.text.ParagraphStyle
+import androidx.compose.ui.text.SpanStyle
+import androidx.compose.ui.text.font.FontFamily
+import androidx.compose.ui.text.font.FontStyle
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.BaselineShift
 import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.text.style.TextDecoration
+import androidx.compose.ui.text.style.TextGeometricTransform
 import com.backbase.deferredresources.DeferredText
 import com.backbase.deferredresources.compose.test.GenericValueNode
 import com.backbase.deferredresources.compose.test.R
@@ -62,6 +70,99 @@ internal class DeferredTextAdapterTest {
         }
 
         composeTestRule.onNodeWithTag(TestTag).assertGenericValueEquals(AnnotatedString("A string"))
+    }
+
+    @Test fun rememberResolvedAnnotatedString_resolvingStyledResourceString_retainsStyleElements() {
+        val deferred = DeferredText.Resource(
+            resId = com.backbase.deferredresources.demo.core.R.string.styled_string,
+            type = DeferredText.Resource.Type.TEXT,
+        )
+        composeTestRule.setContent {
+            GenericValueNode(
+                value = rememberResolvedAnnotatedString(deferred),
+                modifier = TestTagModifier,
+            )
+        }
+
+        composeTestRule.onNodeWithTag(TestTag).assertGenericValueEquals(
+            AnnotatedString(
+                text = """
+                    Styled text is supported:
+
+                    Bold, italic, underlined, struck through, and colorful.
+
+                    Sans-serif, serif, cursive, or monospace.
+
+                    Superscript or subscript, big or small.
+
+                    These styles can also be combined:
+                    y = x2 - 4x + 7
+                """.trimIndent(),
+                // FIXME: Still fails
+                spanStyles = listOf(
+                    AnnotatedString.Range(item = SpanStyle(fontWeight = FontWeight.Bold), start = 28, end = 33),
+                    AnnotatedString.Range(item = SpanStyle(fontStyle = FontStyle.Italic), start = 34, end = 41),
+                    AnnotatedString.Range(item = SpanStyle(fontStyle = FontStyle.Italic), start = 208, end = 209),
+                    AnnotatedString.Range(item = SpanStyle(fontStyle = FontStyle.Italic), start = 212, end = 213),
+                    AnnotatedString.Range(item = SpanStyle(fontStyle = FontStyle.Italic), start = 218, end = 219),
+                    AnnotatedString.Range(
+                        item = SpanStyle(textDecoration = TextDecoration.Underline),
+                        start = 42,
+                        end = 53
+                    ),
+                    AnnotatedString.Range(
+                        item = SpanStyle(textDecoration = TextDecoration.LineThrough),
+                        start = 54,
+                        end = 69
+                    ),
+                    AnnotatedString.Range(
+                        item = SpanStyle(baselineShift = BaselineShift(multiplier = 0.5f)),
+                        start = 130,
+                        end = 135
+                    ),
+                    AnnotatedString.Range(
+                        item = SpanStyle(baselineShift = BaselineShift(multiplier = 0.5f)),
+                        start = 213,
+                        end = 214
+                    ),
+                    AnnotatedString.Range(
+                        item = SpanStyle(baselineShift = BaselineShift(multiplier = -0.5f)),
+                        start = 145,
+                        end = 148
+                    ),
+                    AnnotatedString.Range(item = SpanStyle(color = Color(0xfff2780c)), start = 74, end = 83),
+                    AnnotatedString.Range(item = SpanStyle(fontFamily = FontFamily.SansSerif), start = 86, end = 97),
+                    AnnotatedString.Range(item = SpanStyle(fontFamily = FontFamily.Serif), start = 98, end = 104),
+                    AnnotatedString.Range(item = SpanStyle(fontFamily = FontFamily.Cursive), start = 105, end = 113),
+                    AnnotatedString.Range(item = SpanStyle(fontFamily = FontFamily.Monospace), start = 117, end = 127),
+                    AnnotatedString.Range(item = SpanStyle(fontFamily = FontFamily.Serif), start = 208, end = 223),
+                    AnnotatedString.Range(
+                        item = SpanStyle(
+                            textGeometricTransform = TextGeometricTransform(
+                                scaleX = 1.25f,
+                                skewX = 0f
+                            )
+                        ), start = 156, end = 159
+                    ),
+                    AnnotatedString.Range(
+                        item = SpanStyle(
+                            textGeometricTransform = TextGeometricTransform(
+                                scaleX = 0.8f,
+                                skewX = 0f
+                            )
+                        ), start = 163, end = 168
+                    ),
+                    AnnotatedString.Range(
+                        item = SpanStyle(
+                            textGeometricTransform = TextGeometricTransform(
+                                scaleX = 0.8f,
+                                skewX = 0f
+                            )
+                        ), start = 213, end = 214
+                    ),
+                ),
+            )
+        )
     }
 
     @Test fun resolveToString_withLocalContext_returnsExpectedValue() {

--- a/deferred-resources-compose-adapter/src/androidTest/java/com/backbase/deferredresources/compose/DeferredTextAdapterTest.kt
+++ b/deferred-resources-compose-adapter/src/androidTest/java/com/backbase/deferredresources/compose/DeferredTextAdapterTest.kt
@@ -16,6 +16,7 @@
 
 package com.backbase.deferredresources.compose
 
+import android.os.Build
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.compose.ui.test.onNodeWithTag
@@ -131,7 +132,19 @@ internal class DeferredTextAdapterTest {
                     start = 145,
                     end = 148,
                 ),
-                AnnotatedString.Range(item = SpanStyle(color = Color(0xfff2780c)), start = 74, end = 83),
+                AnnotatedString.Range(
+                    item = SpanStyle(
+                        color = Color(
+                            red = 0xf2,
+                            green = 0x78,
+                            blue = 0x0c,
+                            // Color incorrectly has alpha 0 on Lollipop:
+                            alpha = if (Build.VERSION.SDK_INT < 23) 0x00 else 0xff,
+                        )
+                    ),
+                    start = 74,
+                    end = 83
+                ),
                 AnnotatedString.Range(item = SpanStyle(fontFamily = FontFamily.Cursive), start = 105, end = 113),
                 AnnotatedString.Range(item = SpanStyle(fontFamily = FontFamily.Monospace), start = 117, end = 127),
                 AnnotatedString.Range(item = SpanStyle(fontFamily = FontFamily.SansSerif), start = 86, end = 97),

--- a/deferred-resources-compose-adapter/src/androidTest/java/com/backbase/deferredresources/compose/DeferredTextAdapterTest.kt
+++ b/deferred-resources-compose-adapter/src/androidTest/java/com/backbase/deferredresources/compose/DeferredTextAdapterTest.kt
@@ -35,6 +35,8 @@ import com.backbase.deferredresources.compose.test.R
 import com.backbase.deferredresources.compose.test.TestTag
 import com.backbase.deferredresources.compose.test.TestTagModifier
 import com.backbase.deferredresources.compose.test.assertGenericValueEquals
+import com.backbase.deferredresources.compose.test.assertGenericValueSemanticallyMatches
+import com.google.common.truth.Truth.assertThat
 import org.junit.Rule
 import org.junit.Test
 
@@ -84,85 +86,80 @@ internal class DeferredTextAdapterTest {
             )
         }
 
-        composeTestRule.onNodeWithTag(TestTag).assertGenericValueEquals(
-            AnnotatedString(
-                text = """
-                    Styled text is supported:
+        val space = " "
+        val expected = AnnotatedString(
+            text = """
+                Styled text is supported:$space
 
-                    Bold, italic, underlined, struck through, and colorful.
+                Bold, italic, underlined, struck through, and colorful.$space
 
-                    Sans-serif, serif, cursive, or monospace.
+                Sans-serif, serif, cursive, or monospace.$space
 
-                    Superscript or subscript, big or small.
+                Superscript or subscript, big or small.$space
 
-                    These styles can also be combined:
-                    y = x2 - 4x + 7
-                """.trimIndent(),
-                // FIXME: Still fails
-                spanStyles = listOf(
-                    AnnotatedString.Range(item = SpanStyle(fontWeight = FontWeight.Bold), start = 28, end = 33),
-                    AnnotatedString.Range(item = SpanStyle(fontStyle = FontStyle.Italic), start = 34, end = 41),
-                    AnnotatedString.Range(item = SpanStyle(fontStyle = FontStyle.Italic), start = 208, end = 209),
-                    AnnotatedString.Range(item = SpanStyle(fontStyle = FontStyle.Italic), start = 212, end = 213),
-                    AnnotatedString.Range(item = SpanStyle(fontStyle = FontStyle.Italic), start = 218, end = 219),
-                    AnnotatedString.Range(
-                        item = SpanStyle(textDecoration = TextDecoration.Underline),
-                        start = 42,
-                        end = 53
-                    ),
-                    AnnotatedString.Range(
-                        item = SpanStyle(textDecoration = TextDecoration.LineThrough),
-                        start = 54,
-                        end = 69
-                    ),
-                    AnnotatedString.Range(
-                        item = SpanStyle(baselineShift = BaselineShift(multiplier = 0.5f)),
-                        start = 130,
-                        end = 135
-                    ),
-                    AnnotatedString.Range(
-                        item = SpanStyle(baselineShift = BaselineShift(multiplier = 0.5f)),
-                        start = 213,
-                        end = 214
-                    ),
-                    AnnotatedString.Range(
-                        item = SpanStyle(baselineShift = BaselineShift(multiplier = -0.5f)),
-                        start = 145,
-                        end = 148
-                    ),
-                    AnnotatedString.Range(item = SpanStyle(color = Color(0xfff2780c)), start = 74, end = 83),
-                    AnnotatedString.Range(item = SpanStyle(fontFamily = FontFamily.SansSerif), start = 86, end = 97),
-                    AnnotatedString.Range(item = SpanStyle(fontFamily = FontFamily.Serif), start = 98, end = 104),
-                    AnnotatedString.Range(item = SpanStyle(fontFamily = FontFamily.Cursive), start = 105, end = 113),
-                    AnnotatedString.Range(item = SpanStyle(fontFamily = FontFamily.Monospace), start = 117, end = 127),
-                    AnnotatedString.Range(item = SpanStyle(fontFamily = FontFamily.Serif), start = 208, end = 223),
-                    AnnotatedString.Range(
-                        item = SpanStyle(
-                            textGeometricTransform = TextGeometricTransform(
-                                scaleX = 1.25f,
-                                skewX = 0f
-                            )
-                        ), start = 156, end = 159
-                    ),
-                    AnnotatedString.Range(
-                        item = SpanStyle(
-                            textGeometricTransform = TextGeometricTransform(
-                                scaleX = 0.8f,
-                                skewX = 0f
-                            )
-                        ), start = 163, end = 168
-                    ),
-                    AnnotatedString.Range(
-                        item = SpanStyle(
-                            textGeometricTransform = TextGeometricTransform(
-                                scaleX = 0.8f,
-                                skewX = 0f
-                            )
-                        ), start = 213, end = 214
-                    ),
+                These styles can also be combined:$space
+                y = x2 - 4x + 7$space
+            """.trimIndent(),
+            spanStyles = listOf(
+                AnnotatedString.Range(item = SpanStyle(fontWeight = FontWeight.Bold), start = 28, end = 33),
+                AnnotatedString.Range(item = SpanStyle(fontStyle = FontStyle.Italic), start = 34, end = 41),
+                AnnotatedString.Range(item = SpanStyle(fontStyle = FontStyle.Italic), start = 208, end = 209),
+                AnnotatedString.Range(item = SpanStyle(fontStyle = FontStyle.Italic), start = 212, end = 213),
+                AnnotatedString.Range(item = SpanStyle(fontStyle = FontStyle.Italic), start = 218, end = 219),
+                AnnotatedString.Range(
+                    item = SpanStyle(textDecoration = TextDecoration.Underline),
+                    start = 42,
+                    end = 53,
                 ),
-            )
+                AnnotatedString.Range(
+                    item = SpanStyle(textDecoration = TextDecoration.LineThrough),
+                    start = 54,
+                    end = 69,
+                ),
+                AnnotatedString.Range(
+                    item = SpanStyle(baselineShift = BaselineShift(multiplier = 0.5f)),
+                    start = 130,
+                    end = 135,
+                ),
+                AnnotatedString.Range(
+                    item = SpanStyle(baselineShift = BaselineShift(multiplier = 0.5f)),
+                    start = 213,
+                    end = 214,
+                ),
+                AnnotatedString.Range(
+                    item = SpanStyle(baselineShift = BaselineShift(multiplier = -0.5f)),
+                    start = 145,
+                    end = 148,
+                ),
+                AnnotatedString.Range(item = SpanStyle(color = Color(0xfff2780c)), start = 74, end = 83),
+                AnnotatedString.Range(item = SpanStyle(fontFamily = FontFamily.Cursive), start = 105, end = 113),
+                AnnotatedString.Range(item = SpanStyle(fontFamily = FontFamily.Monospace), start = 117, end = 127),
+                AnnotatedString.Range(item = SpanStyle(fontFamily = FontFamily.SansSerif), start = 86, end = 97),
+                AnnotatedString.Range(item = SpanStyle(fontFamily = FontFamily.Serif), start = 98, end = 104),
+                AnnotatedString.Range(item = SpanStyle(fontFamily = FontFamily.Serif), start = 208, end = 223),
+                AnnotatedString.Range(
+                    item = SpanStyle(textGeometricTransform = TextGeometricTransform(scaleX = 1.25f, skewX = 0f)),
+                    start = 156,
+                    end = 159,
+                ),
+                AnnotatedString.Range(
+                    item = SpanStyle(textGeometricTransform = TextGeometricTransform(scaleX = 0.8f, skewX = 0f)),
+                    start = 163,
+                    end = 168,
+                ),
+                AnnotatedString.Range(
+                    item = SpanStyle(textGeometricTransform = TextGeometricTransform(scaleX = 0.8f, skewX = 0f)),
+                    start = 213,
+                    end = 214,
+                ),
+            ),
         )
+        composeTestRule.onNodeWithTag(TestTag).assertGenericValueSemanticallyMatches<AnnotatedString> { value ->
+            assertThat(value.text).isEqualTo(expected.text)
+            assertThat(value.spanStyles).hasSize(expected.spanStyles.size)
+            // `inOrder` is intentionally not called because we do not care about the order:
+            assertThat(value.spanStyles).containsExactlyElementsIn(expected.spanStyles)
+        }
     }
 
     @Test fun resolveToString_withLocalContext_returnsExpectedValue() {

--- a/deferred-resources-compose-adapter/src/androidTest/java/com/backbase/deferredresources/compose/test/GenericValueNode.kt
+++ b/deferred-resources-compose-adapter/src/androidTest/java/com/backbase/deferredresources/compose/test/GenericValueNode.kt
@@ -46,4 +46,20 @@ import androidx.compose.ui.test.assert
 internal fun <T> SemanticsNodeInteraction.assertGenericValueEquals(value: T) =
     assert(SemanticsMatcher.expectValue(GenericValue, value))
 
+/**
+ * Assert that the node is a [GenericValueNode] with a value matching the given [assertions].
+ */
+internal inline fun <reified T : Any> SemanticsNodeInteraction.assertGenericValueSemanticallyMatches(
+    crossinline assertions: (T) -> Unit,
+) {
+    val node = fetchSemanticsNode()
+    val value = node.config.getOrElseNullable(GenericValue) { null }
+
+    if (value is T) {
+        assertions(value)
+    } else {
+        "Expected instance of ${T::class.java.simpleName}, but got <$value>"
+    }
+}
+
 private val GenericValue = SemanticsPropertyKey<Any?>("GenericValue") { parentNode, _ -> parentNode }

--- a/deferred-resources-compose-adapter/src/main/java/com/backbase/deferredresources/compose/DeferredTextAdapter.kt
+++ b/deferred-resources-compose-adapter/src/main/java/com/backbase/deferredresources/compose/DeferredTextAdapter.kt
@@ -28,10 +28,12 @@ import android.text.style.SubscriptSpan
 import android.text.style.SuperscriptSpan
 import android.text.style.TypefaceSpan
 import android.text.style.UnderlineSpan
+import androidx.annotation.StringRes
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.remember
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.AnnotatedString
 import androidx.compose.ui.text.SpanStyle
 import androidx.compose.ui.text.font.FontFamily
@@ -45,8 +47,6 @@ import com.backbase.deferredresources.text.resolveToString
 
 /**
  * Resolve [deferredText], remembering the resulting value as long as the current [LocalContext] doesn't change.
- *
- * Note: Currently, style elements from resource-resolved text are not kept.
  */
 @ExperimentalComposeAdapter
 @Composable public fun rememberResolvedAnnotatedString(deferredText: DeferredText): AnnotatedString {
@@ -54,25 +54,25 @@ import com.backbase.deferredresources.text.resolveToString
     return remember(deferredText) {
         when (val text = deferredText.resolve(context)) {
             is AnnotatedString -> text
-            is SpannedString -> {
-                AnnotatedString(
-                    text = text.toString(),
-                    spanStyles = mutableListOf<AnnotatedString.Range<SpanStyle>>().apply {
-                        addSpansFromText<StyleSpan>(text)
-                        addSpansFromText<UnderlineSpan>(text)
-                        addSpansFromText<StrikethroughSpan>(text)
-                        addSpansFromText<SuperscriptSpan>(text)
-                        addSpansFromText<SubscriptSpan>(text)
-                        addSpansFromText<ForegroundColorSpan>(text)
-                        addSpansFromText<TypefaceSpan>(text)
-                        addSpansFromText<RelativeSizeSpan>(text)
-                    }
-                )
-            }
+            is SpannedString -> AnnotatedString(text)
             else -> AnnotatedString(text.toString())
         }
     }
 }
+
+private fun AnnotatedString(text: SpannedString) = AnnotatedString(
+    text = text.toString(),
+    spanStyles = mutableListOf<AnnotatedString.Range<SpanStyle>>().apply {
+        addSpansFromText<StyleSpan>(text)
+        addSpansFromText<UnderlineSpan>(text)
+        addSpansFromText<StrikethroughSpan>(text)
+        addSpansFromText<SuperscriptSpan>(text)
+        addSpansFromText<SubscriptSpan>(text)
+        addSpansFromText<ForegroundColorSpan>(text)
+        addSpansFromText<TypefaceSpan>(text)
+        addSpansFromText<RelativeSizeSpan>(text)
+    }
+)
 
 private inline fun <reified T : CharacterStyle> MutableList<AnnotatedString.Range<SpanStyle>>.addSpansFromText(
     text: SpannedString

--- a/demo-compose/src/main/java/com/backbase/deferredresources/demo/compose/ComposeDemoActivity.kt
+++ b/demo-compose/src/main/java/com/backbase/deferredresources/demo/compose/ComposeDemoActivity.kt
@@ -24,9 +24,9 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.material.MaterialTheme
+import androidx.compose.material.ScrollableTabRow
 import androidx.compose.material.Surface
 import androidx.compose.material.Tab
-import androidx.compose.material.TabRow
 import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
@@ -81,7 +81,7 @@ class ComposeDemoActivity : ComponentActivity() {
                 }
 
                 Surface(elevation = 4.dp) {
-                    TabRow(
+                    ScrollableTabRow(
                         selectedTabIndex = pagerState.currentPage,
                         modifier = Modifier
                             .fillMaxWidth()
@@ -107,6 +107,12 @@ class ComposeDemoActivity : ComponentActivity() {
                             pagerState = pagerState,
                             coroutineScope = coroutineScope,
                         )
+                        SampleTab(
+                            text = viewModel.textSampleTitle,
+                            index = 3,
+                            pagerState = pagerState,
+                            coroutineScope = coroutineScope,
+                        )
                     }
                 }
 
@@ -117,6 +123,7 @@ class ComposeDemoActivity : ComponentActivity() {
                         0 -> ColorSamplesPage(viewModel.colorSamples)
                         1 -> PluralsSamplePage(viewModel.formattedPluralsSample)
                         2 -> IconSamplesPage(viewModel.iconSamples)
+                        3 -> TextSamplePage(viewModel.textSample)
                     }
                 }
             }
@@ -136,13 +143,14 @@ class ComposeDemoActivity : ComponentActivity() {
                 pagerState.animateScrollToPage(index, skipPages = false)
             }
         },
-    ) {
-        Text(text = rememberResolvedAnnotatedString(text))
-    }
+        text = {
+            Text(text = rememberResolvedAnnotatedString(text))
+        },
+    )
 
     private fun mutablePagerState(currentPage: Int = 0) = mutableStateOf(
         PagerState(
-            pageCount = 3,
+            pageCount = 4,
             currentPage = currentPage,
         )
     )

--- a/demo-compose/src/main/java/com/backbase/deferredresources/demo/compose/TextSamplePage.kt
+++ b/demo-compose/src/main/java/com/backbase/deferredresources/demo/compose/TextSamplePage.kt
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2021 Backbase R&D B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.backbase.deferredresources.demo.compose
+
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.material.MaterialTheme
+import androidx.compose.material.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import com.backbase.deferredresources.DeferredText
+import com.backbase.deferredresources.compose.ExperimentalComposeAdapter
+import com.backbase.deferredresources.compose.rememberResolvedAnnotatedString
+
+@Preview
+@Composable
+private fun TextSamplePage() = TextSamplePage(
+    text = DeferredText.Resource(R.string.styled_string),
+)
+
+@OptIn(ExperimentalComposeAdapter::class)
+@Composable
+fun TextSamplePage(
+    text: DeferredText,
+    modifier: Modifier = Modifier,
+) = LazyColumn(
+    modifier = modifier.fillMaxSize()
+) {
+    item {
+        Text(
+            text = rememberResolvedAnnotatedString(text),
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(16.dp),
+            style = MaterialTheme.typography.body1,
+        )
+    }
+}

--- a/demo-core/src/main/java/com/backbase/deferredresources/demo/core/SamplesViewModel.kt
+++ b/demo-core/src/main/java/com/backbase/deferredresources/demo/core/SamplesViewModel.kt
@@ -91,6 +91,19 @@ public data class SamplesViewModel(
             description = DeferredText.Constant("Attribute"),
         ),
     ),
+
+    /**
+     * Title of the section displaying a [textSample].
+     */
+    public val textSampleTitle: DeferredText = DeferredText.Constant("Styled text"),
+
+    /**
+     * The styled [DeferredText] to display.
+     */
+    public val textSample: DeferredText = DeferredText.Resource(
+        resId = R.string.styled_string,
+        type = DeferredText.Resource.Type.TEXT,
+    ),
 ) : ViewModel() {
 
     private companion object {

--- a/demo-core/src/main/res/values/strings.xml
+++ b/demo-core/src/main/res/values/strings.xml
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  ~ Copyright 2021 Backbase R&D B.V.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<resources>
+
+  <string name="styled_string" translatable="false">Styled text is supported:
+    \n\n<b>Bold,</b> <i>italic,</i> <u>underlined,</u> <strike>struck through,</strike> and
+    <font color="#f2780c">colorful.</font>
+
+    \n\n<font face="sans-serif">Sans-serif,</font> <font face="serif">serif,</font> <font face="cursive">cursive,</font>
+    or <tt>monospace.</tt>
+
+    \n\n<sup>Super</sup>script or <sub>sub</sub>script, <big>big</big> or <small>small</small>.
+
+    \n\nThese styles can also be combined:
+    \n<font face="serif"><i>y</i> = <i>x</i><sup><small>2</small></sup> - 4<i>x</i> + 7</font>
+  </string>
+
+</resources>

--- a/demo/src/main/java/com/backbase/deferredresources/demo/DeferredResourceViews.kt
+++ b/demo/src/main/java/com/backbase/deferredresources/demo/DeferredResourceViews.kt
@@ -36,6 +36,7 @@ import com.backbase.deferredresources.demo.databinding.ColorsBinding
 import com.backbase.deferredresources.demo.databinding.DrawableListItemBinding
 import com.backbase.deferredresources.demo.databinding.DrawablesBinding
 import com.backbase.deferredresources.demo.databinding.PluralsBinding
+import com.backbase.deferredresources.demo.databinding.TextBinding
 import com.backbase.deferredresources.viewx.setImageDrawable
 import com.backbase.deferredresources.viewx.setText
 import com.google.android.material.textview.MaterialTextView
@@ -102,5 +103,13 @@ class DeferredDrawablesView(context: Context) : DeferredResourceView(context) {
             drawableLabel.setText(text)
             drawableView.setImageDrawable(drawable)
         }
+    }
+}
+
+class DeferredTextView(context: Context) : DeferredResourceView(context) {
+    private val binding = TextBinding.inflate(LayoutInflater.from(context), this)
+
+    fun display(text: DeferredText) {
+        binding.textView.setText(text)
     }
 }

--- a/demo/src/main/java/com/backbase/deferredresources/demo/DemoPagerAdapter.kt
+++ b/demo/src/main/java/com/backbase/deferredresources/demo/DemoPagerAdapter.kt
@@ -30,6 +30,7 @@ class DemoPagerAdapter(
         0 -> viewModel.colorSamplesTitle
         1 -> viewModel.formattedPluralsSampleTitle
         2 -> viewModel.iconSamplesTitle
+        3 -> viewModel.textSampleTitle
         else -> throw IllegalArgumentException("Position $position in adapter with size $itemCount")
     }
 
@@ -39,6 +40,7 @@ class DemoPagerAdapter(
         0 -> ViewType.COLORS.ordinal
         1 -> ViewType.PLURALS.ordinal
         2 -> ViewType.DRAWABLES.ordinal
+        3 -> ViewType.STYLED_TEXT.ordinal
         else -> throw IndexOutOfBoundsException("Position $position in adapter with size $itemCount")
     }
 
@@ -47,6 +49,7 @@ class DemoPagerAdapter(
             ViewType.COLORS -> DeferredColorsView(parent.context)
             ViewType.PLURALS -> DeferredPluralsView(parent.context)
             ViewType.DRAWABLES -> DeferredDrawablesView(parent.context)
+            ViewType.STYLED_TEXT -> DeferredTextView(parent.context)
         }.apply {
             layoutParams = LinearLayout.LayoutParams(
                 ViewGroup.LayoutParams.MATCH_PARENT,
@@ -65,6 +68,7 @@ class DemoPagerAdapter(
             is DeferredDrawablesView -> viewModel.iconSamples.forEach { sample ->
                 view.display(sample.icon, sample.description)
             }
+            is DeferredTextView -> view.display(viewModel.textSample)
         }
     }
 
@@ -73,6 +77,6 @@ class DemoPagerAdapter(
     ) : RecyclerView.ViewHolder(root)
 
     private enum class ViewType {
-        COLORS, PLURALS, DRAWABLES
+        COLORS, PLURALS, DRAWABLES, STYLED_TEXT,
     }
 }

--- a/demo/src/main/res/layout/text.xml
+++ b/demo/src/main/res/layout/text.xml
@@ -15,33 +15,21 @@
   ~ limitations under the License.
   -->
 
-<LinearLayout
+<merge
     xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
-    android:layout_width="match_parent"
-    android:layout_height="match_parent"
 
-    android:orientation="vertical">
+    tools:layout_height="match_parent"
+    tools:layout_width="match_parent"
 
-  <com.google.android.material.tabs.TabLayout
-      android:id="@+id/tabs"
-      style="@style/Widget.MaterialComponents.TabLayout.Colored"
+    tools:parentTag="android.widget.ScrollView">
+
+  <TextView
+      android:id="@+id/textView"
       android:layout_width="match_parent"
       android:layout_height="wrap_content"
 
-      android:elevation="4dp"
+      android:padding="16dp"
+      android:textAppearance="?textAppearanceBody1" />
 
-      app:tabMode="scrollable"
-
-      tools:ignore="UnusedAttribute" />
-
-  <androidx.viewpager2.widget.ViewPager2
-      android:id="@+id/pager"
-      android:layout_width="match_parent"
-      android:layout_height="0dp"
-      android:layout_weight="1"
-
-      tools:listitem="@layout/plurals" />
-
-</LinearLayout>
+</merge>


### PR DESCRIPTION
This converts the SpannedString resolved by `Resources.getText` to a styled `AnnotatedString` by mapping each `*Span` class to a corresponding Compose `StyleSpan`. Adapted from https://stackoverflow.com/a/67797256/6194604.

Also adds styled text to both demo apps.