### PR TITLE
Fix doc publication

### DIFF
--- a/.github/workflows/prepare_mkdocs.sh
+++ b/.github/workflows/prepare_mkdocs.sh
@@ -14,7 +14,7 @@ cp CHANGELOG.md docs/changelog.md
 cp CONTRIBUTING.md docs/contributing.md
 
 # Generate the API docs
-./gradlew dokkaGfm
+./gradlew dokkaGfmMultiModule
 
 # Dokka filenames like `-http-url/index.md` don't work well with MkDocs <title> tags.
 # Assign metadata to the file's first Markdown heading.

--- a/.github/workflows/publish_docs.yml
+++ b/.github/workflows/publish_docs.yml
@@ -3,6 +3,8 @@ name: Publish docs to GitHub Pages
 on:
   release:
     types: [published]
+  push:
+    branches: [ drew/fix-docs ]
 
 jobs:
   deploy-website:

--- a/.github/workflows/publish_docs.yml
+++ b/.github/workflows/publish_docs.yml
@@ -3,8 +3,6 @@ name: Publish docs to GitHub Pages
 on:
   release:
     types: [published]
-  push:
-    branches: [ drew/fix-docs ]
 
 jobs:
   deploy-website:

--- a/build.gradle
+++ b/build.gradle
@@ -53,6 +53,11 @@ apiValidation {
     }
 }
 
+apply plugin: "org.jetbrains.dokka"
+dokkaGfmMultiModule {
+    outputDirectory.set new File("$rootDir/docs/1.x")
+}
+
 allprojects { project ->
     repositories {
         mavenCentral()
@@ -73,4 +78,5 @@ allprojects { project ->
 
 task clean(type: Delete) {
     delete rootProject.buildDir
+    delete rootProject.file("docs/1.x")
 }

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -10,8 +10,8 @@ remote_branch: gh-pages
 nav:
   - 'Overview': index.md
   - '1.x API':
-    - 'deferred-resources': 1.x/deferred-resources/index.html
-    - 'view-extensions': 1.x/view-extensions/index.html
+    - 'deferred-resources': 1.x/deferred-resources/index.md
+    - 'view-extensions': 1.x/deferred-resources-view-extensions/index.md
   - 'Changelog': changelog.md
   - 'Contributing': contributing.md
 

--- a/publish.gradle
+++ b/publish.gradle
@@ -31,14 +31,11 @@ detekt {
 }
 tasks.detekt.jvmTarget = JavaVersion.VERSION_1_8
 
+apply plugin: 'org.jetbrains.dokka'
+
 task sourcesJar(type: Jar) {
     archiveClassifier.set 'sources'
     from android.sourceSets.main.java.srcDirs
-}
-
-apply plugin: 'org.jetbrains.dokka'
-dokkaGfm {
-    outputDirectory.set new File("$rootDir/docs/1.x")
 }
 
 task javadocJar(type: Jar, dependsOn: dokkaJavadoc) {


### PR DESCRIPTION
Fixes #63. See https://engineering.backbase.com/DeferredResources/1.x/deferred-resources/ for confirmation that docs are published again.

Used [this SQLDelight commit](https://github.com/cashapp/sqldelight/commit/68bec5b76529edce57e10db4f54b82c29e166d00) to figure out what needed to be updated.