### PR TITLE
Set `useIR` to false for non-Compose modules

### DIFF
--- a/deferred-resources-view-extensions/build.gradle
+++ b/deferred-resources-view-extensions/build.gradle
@@ -51,6 +51,7 @@ android {
     kotlinOptions {
         jvmTarget = JavaVersion.VERSION_1_8
         freeCompilerArgs += ['-Xexplicit-api=strict']
+        useIR = false
     }
 }
 

--- a/deferred-resources/build.gradle
+++ b/deferred-resources/build.gradle
@@ -53,6 +53,7 @@ android {
     kotlinOptions {
         jvmTarget = JavaVersion.VERSION_1_8
         freeCompilerArgs += ['-Xexplicit-api=strict']
+        useIR = false
     }
 }
 


### PR DESCRIPTION
Improves compatibility with projects still on Kotlin 1.4