### PR TITLE
PR-based release

### DIFF
--- a/.github/workflows/publish_docs.yml
+++ b/.github/workflows/publish_docs.yml
@@ -16,9 +16,9 @@ jobs:
         run: .github/workflows/prepare_mkdocs.sh
 
       - name: Deploy docs
-        uses: mhausenblas/mkdocs-deploy-gh-pages@master
+        uses: mhausenblas/mkdocs-deploy-gh-pages@1.21
         env:
-          PERSONAL_TOKEN: ${{ secrets.MKDOCS_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
 env:
   GRADLE_OPTS: -Dorg.gradle.configureondemand=true -Dorg.gradle.parallel=true -Dkotlin.incremental=false -Dorg.gradle.jvmargs="-Xmx3g -XX:MaxPermSize=2048m -XX:+HeapDumpOnOutOfMemoryError -Dfile.encoding=UTF-8"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -52,7 +52,7 @@ jobs:
       - name: Check out the repo
         uses: actions/checkout@v2
         with:
-          token: ${{ secrets.BACKBASE_BOT_TOKEN }}
+          token: ${{ secrets.ACCESS_TOKEN }}
       - name: Bump to next development version
         run: ./gradlew bumpToNextDevelopmentVersion
       - name: Push version to main

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,7 +15,7 @@ jobs:
     steps:
       - name: Parse release version
         id: version
-        uses: madhead/read-java-properties
+        uses: madhead/read-java-properties@1.1
         with:
           file: gradle.properties
           property: libraryVersion

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,6 +13,8 @@ jobs:
       version: ${{ steps.version.outputs.value }}
 
     steps:
+      - name: Check out the repo
+        uses: actions/checkout@v2
       - name: Parse release version
         id: version
         uses: madhead/read-java-properties@1.1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,8 +2,8 @@ name: Release
 
 on:
   push:
-    branches: [main]
-    tags: ['*']
+    branches: [ main ]
+    tags: [ '*' ]
 
 jobs:
   release:
@@ -23,3 +23,22 @@ jobs:
           ORG_GRADLE_PROJECT_backbaseOssGpgKey: ${{ secrets.ORG_GRADLE_PROJECT_backbaseOssGpgKey }}
           ORG_GRADLE_PROJECT_backbaseOssGpgPassword: ${{ secrets.ORG_GRADLE_PROJECT_backbaseOssGpgPassword }}
         run: ./gradlew publishReleasePublicationToMavenCentralRepository --stacktrace
+
+  prepare-next-development-version:
+    runs-on: ubuntu-latest
+    # Only runs on tagged releases:
+    if: startsWith(github.ref, 'refs/tags/')
+    steps:
+      - name: Check out the repo
+        uses: actions/checkout@v2
+        with:
+          token: ${{ secrets.BACKBASE_BOT_TOKEN }}
+      - name: Bump to next development version
+        run: ./gradlew bumpToNextDevelopmentVersion
+      - name: Push version to main
+        uses: stefanzweifel/git-auto-commit-action@v4
+        with:
+          commit_message: Prepare next development version
+          branch: main
+          file_pattern: gradle.properties
+          commit_author: GitHub Actions <actions@github.com>

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,7 +6,24 @@ on:
     tags: [ '*' ]
 
 jobs:
+  prepare:
+    runs-on: ubuntu-latest
+
+    outputs:
+      version: ${{ steps.version.outputs.value }}
+
+    steps:
+      - name: Parse release version
+        id: version
+        uses: madhead/read-java-properties
+        with:
+          file: gradle.properties
+          property: libraryVersion
+
   release:
+    needs: prepare
+    # Only proceed for tagged releases and snapshots:
+    if: startsWith(github.ref, 'refs/tags/') || endsWith(needs.prepare.outputs.version, '-SNAPSHOT')
     runs-on: ubuntu-latest
 
     steps:
@@ -25,8 +42,9 @@ jobs:
         run: ./gradlew publishReleasePublicationToMavenCentralRepository --stacktrace
 
   prepare-next-development-version:
+    needs: release
     runs-on: ubuntu-latest
-    # Only runs on tagged releases:
+    # Only proceed for tagged releases:
     if: startsWith(github.ref, 'refs/tags/')
     steps:
       - name: Check out the repo

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,7 +2,7 @@ name: Release
 
 on:
   push:
-    branches: [ main ]
+    branches: [ main, drew/pr-based-release ]
     tags: [ '*' ]
 
 jobs:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,7 +2,7 @@ name: Release
 
 on:
   push:
-    branches: [ main, drew/pr-based-release ]
+    branches: [ main ]
     tags: [ '*' ]
 
 jobs:
@@ -59,6 +59,6 @@ jobs:
         uses: stefanzweifel/git-auto-commit-action@v4
         with:
           commit_message: Prepare next development version
-          branch: drew/pr-based-release
+          branch: main
           file_pattern: gradle.properties
           commit_author: GitHub Actions <actions@github.com>

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -59,6 +59,6 @@ jobs:
         uses: stefanzweifel/git-auto-commit-action@v4
         with:
           commit_message: Prepare next development version
-          branch: main
+          branch: drew/pr-based-release
           file_pattern: gradle.properties
           commit_author: GitHub Actions <actions@github.com>

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,12 +1,12 @@
 # Releasing
 
  1. Make sure you're on the main branch.
- 2. Change `ext.libraryVersion` in the root build.gradle to a non-SNAPSHOT version.
+ 2. Change `libraryVersion` in the root gradle.properties to a non-SNAPSHOT version.
  3. Update CHANGELOG.md for the impending release.
  4. If necessary, update README.md and docs/index.md.
  5. Commit (don't push) the changes with message "Release x.y.z", where x.y.z is the new version.
  6. Tag the commit `x.y.z`, where x.y.z is the new version.
- 7. Change `ext.libraryVersion` in the root build.gradle to the next SNAPSHOT version.
+ 7. Change `libraryVersion` in the root gradle.properties to the next SNAPSHOT version.
  8. Commit the SNAPSHOT change.
  9. Push the 2 commits + 1 tag to origin/main.
 10. Wait for the "release" Action to complete.

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,19 +1,21 @@
 # Releasing
 
- 1. Make sure you're on the main branch.
- 2. Change `libraryVersion` in the root gradle.properties to a non-SNAPSHOT version.
- 3. Update CHANGELOG.md for the impending release.
- 4. If necessary, update README.md and docs/index.md.
- 5. Commit (don't push) the changes with message "Release x.y.z", where x.y.z is the new version.
- 6. Tag the commit `x.y.z`, where x.y.z is the new version.
- 7. Change `libraryVersion` in the root gradle.properties to the next SNAPSHOT version.
- 8. Commit the SNAPSHOT change.
- 9. Push the 2 commits + 1 tag to origin/main.
-10. Wait for the "release" Action to complete.
-11. `startship release -u backbase -p backbaseOssSonatypePassword -c com.backbase.oss.deferredresources:deferred-resources,deferred-resources-view-extensions:x.y.z`
-12. Create the release on GitHub with release notes copied from the changelog.
+In all steps, replace "x.y.z" with the actual version being released.
 
-If step 10 fails, drop the Sonatype repo, fix the problem, commit, and start again at step 6.
+ 1. From the latest main branch commit, create a `release/x.y.z` branch.
+ 2. Change `libraryVersion` in gradle.properties to non-SNAPSHOT version x.y.z.
+ 3. Update CHANGELOG.md for the impending release. Describe all consumer-facing changes since the
+    previous release.
+ 4. If necessary, update README.md and docs/index.md.
+ 5. Commit the changes with message "Release x.y.z".
+ 6. Open a PR to the main branch titled "Release x.y.z". Obtain approval and squash/merge.
+ 7. Tag the merged PR commit `x.y.z` and push the tag.
+ 8. Wait for the "release" Action to complete.
+ 9. `startship release -u backbaseOssSonatypeUsername -p backbaseOssSonatypePassword -c com.backbase.oss.deferredresources:deferred-resources,deferred-resources-view-extensions,deferred-resources-compose-adapter:x.y.z`
+10. Create the release on GitHub with release notes copied from the changelog.
+
+If step 10 fails; drop the Sonatype repo, delete the tag, fix the problem, and start again.
 
 [`startship`](https://github.com/saket/startship) can be installed via Homebrew. You must have
-`backbaseOssSonatypePassword` defined in your machine's gradle.properties file to release.
+`backbaseOssSonatypeUsername` and `backbaseOssSonatypePassword` defined in your machine's
+gradle.properties file to release.

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -18,4 +18,5 @@ If step 10 fails; drop the Sonatype repo, delete the tag, fix the problem, and s
 
 [`startship`](https://github.com/saket/startship) can be installed via Homebrew. You must have
 `backbaseOssSonatypeUsername` and `backbaseOssSonatypePassword` defined in your machine's
-gradle.properties file to release.
+gradle.properties file to release. Alternatively, you could visit [Sonatype Nexus OSS](https://oss.sonatype.org/#stagingRepositories)
+while logged in as Backbase's username to manually drop/promote/release repositories.

--- a/build.gradle
+++ b/build.gradle
@@ -37,8 +37,6 @@ buildscript {
 }
 
 ext {
-    publishGroup = 'com.backbase.oss.deferredresources'
-    libraryVersion = '1.6.0-SNAPSHOT'
     minSdk = 14
     minSdkCompose = 21
     targetSdk = 30

--- a/build.gradle
+++ b/build.gradle
@@ -56,6 +56,8 @@ dokkaGfmMultiModule {
     outputDirectory.set new File("$rootDir/docs/1.x")
 }
 
+apply from: "gradle/version.gradle"
+
 allprojects { project ->
     repositories {
         mavenCentral()

--- a/demo-compose/build.gradle
+++ b/demo-compose/build.gradle
@@ -26,7 +26,7 @@ android {
         minSdkVersion rootProject.ext.minSdkCompose
         targetSdkVersion rootProject.ext.targetSdk
         versionCode 1
-        versionName rootProject.ext.libraryVersion
+        versionName rootProject.libraryVersion
 
         vectorDrawables.useSupportLibrary = true
 

--- a/demo/build.gradle
+++ b/demo/build.gradle
@@ -26,7 +26,7 @@ android {
         minSdkVersion rootProject.ext.minSdk
         targetSdkVersion rootProject.ext.targetSdk
         versionCode 1
-        versionName rootProject.ext.libraryVersion
+        versionName rootProject.libraryVersion
 
         vectorDrawables.useSupportLibrary = true
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -34,7 +34,7 @@ publishGroup=com.backbase.oss.deferredresources
 # Actions for release to fail.
 #  Supported: 1.2.3, 1.3.0, 1.3.0-alpha01, 1.3.1-alpha01, 1.3.1-SNAPSHOT
 #  Not supported: 1.3.0-alpha.1, 1.3.0.1
-libraryVersion=1.6.0-SNAPSHOT
+libraryVersion=1.6.0-a01
 
 # Whether the Compose adapter module is compiled with the project.
 composeEnabled=true

--- a/gradle.properties
+++ b/gradle.properties
@@ -26,6 +26,12 @@ android.enableJetifier=true
 # Kotlin code style for this project: "official" or "obsolete":
 kotlin.code.style=official
 
+# The Deferred Resources Maven publication group
+publishGroup=com.backbase.oss.deferredresources
+
+# The current version of Deferred Resources:
+libraryVersion=1.6.0-SNAPSHOT
+
 # Whether the Compose adapter module is compiled with the project.
 composeEnabled=true
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -34,7 +34,7 @@ publishGroup=com.backbase.oss.deferredresources
 # Actions for release to fail.
 #  Supported: 1.2.3, 1.3.0, 1.3.0-alpha01, 1.3.1-alpha01, 1.3.1-SNAPSHOT
 #  Not supported: 1.3.0-alpha.1, 1.3.0.1
-libraryVersion=1.6.0-a01
+libraryVersion=1.6.0-SNAPSHOT
 
 # Whether the Compose adapter module is compiled with the project.
 composeEnabled=true

--- a/gradle.properties
+++ b/gradle.properties
@@ -29,7 +29,11 @@ kotlin.code.style=official
 # The Deferred Resources Maven publication group
 publishGroup=com.backbase.oss.deferredresources
 
-# The current version of Deferred Resources:
+# The current version of Deferred Resources. Note: Only a three-part semver with an optional hyphenated suffix is
+# supported. Anything else will break assumptions made in gradle/version.gradle, which will cause one of the GitHub
+# Actions for release to fail.
+#  Supported: 1.2.3, 1.3.0, 1.3.0-alpha01, 1.3.1-alpha01, 1.3.1-SNAPSHOT
+#  Not supported: 1.3.0-alpha.1, 1.3.0.1
 libraryVersion=1.6.0-SNAPSHOT
 
 # Whether the Compose adapter module is compiled with the project.

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -7,7 +7,7 @@ poko = "0.8.1"
 
 [libraries]
 accompanist-imageLoading-core = { module = "com.google.accompanist:accompanist-imageloading-core", version.ref = "accompanist" }
-android-gradlePlugin = { module = "com.android.tools.build:gradle", version = "7.0.0-beta04" }
+android-gradlePlugin = { module = "com.android.tools.build:gradle", version = "7.0.0-beta05" }
 androidx-annotations = { module = "androidx.annotation:annotation", version = "1.1.0" }
 androidx-appCompat = { module = "androidx.appcompat:appcompat", version = "1.3.0" }
 androidx-compose-foundation = { module = "androidx.compose.foundation:foundation", version.ref = "androidx-compose" }

--- a/gradle/version.gradle
+++ b/gradle/version.gradle
@@ -1,0 +1,89 @@
+import java.util.function.Function
+
+/*
+ * Copyright 2021 Backbase R&D B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Bumps this project's version, defined in gradle.properties, to the next development (minor) version, with a
+ * "-SNAPSHOT" suffix. The following examples illustrate how this bump is calculated. Note that the last example yields
+ * no change in version.
+ * - 1.2.3          => 1.3.0-SNAPSHOT
+ * - 1.3.0          => 1.4.0-SNAPSHOT
+ * - 1.3.0-alpha01  => 1.3.0-SNAPSHOT
+ * - 1.3.1-alpha01  => 1.3.1-SNAPSHOT
+ * - 1.3.1-SNAPSHOT => 1.3.1-SNAPSHOT
+ */
+task bumpToNextDevelopmentVersion {
+    doLast {
+        replaceVersionName() { currentVersionName ->
+            // Ensure currentVersionName is of the form #.#.#-optionalSuffix. Otherwise, we won't know how to bump.
+            String[] parts = currentVersionName.split("\\.")
+            if (parts.length != 3) {
+                throw IllegalStateException("Expected current version name with 3 parts, but was <$currentVersionName>")
+            }
+            String[] patchParts = parts[2].split("-")
+            if (patchParts.length > 2) {
+                throw IllegalStateException("Expected at most 1 hyphenated suffix, but <$currentVersionName> has more")
+            }
+
+            int majorVersion = Integer.parseInt(parts[0])
+            int minorVersion = Integer.parseInt(parts[1])
+            int patchVersion = Integer.parseInt(patchParts[0])
+            String suffix = patchParts.length > 1 ? patchParts[1] : null
+
+            if (suffix == null) {
+                // If there is no suffix, bump to the next minor snapshot.
+                //  1.2.3 => 1.3.0-SNAPSHOT
+                //  1.3.0 => 1.4.0-SNAPSHOT
+                return "$majorVersion.${minorVersion + 1}.0-SNAPSHOT"
+            } else {
+                // If there is a suffix, it's considered a preview of the next version, so bump to that same version:
+                //  1.3.0-alpha01 => 1.3.0-SNAPSHOT
+                //  1.3.1-alpha01 => 1.3.1-SNAPSHOT
+                //  1.3.1-SNAPSHOT => 1.3.1-SNAPSHOT (i.e. nothing to do)
+                return "$majorVersion.$minorVersion.$patchVersion-SNAPSHOT"
+            }
+        }
+    }
+}
+
+/**
+ * Parses the current library version from gradle.properties, passes that version to the given Action, and then replaces
+ * that version with the result of the Action in gradle.properties.
+ *
+ * @param resolveNewVersionName Action taking the current version name as input and returning the new version name.
+ */
+private void replaceVersionName(Function<String, String> resolveNewVersionName) {
+    File versionFile = new File("$rootDir/gradle.properties")
+    String fileText = versionFile.getText()
+
+    String currentVersionNameDefinition = fileText.find("libraryVersion=.*")
+    String currentVersionName = currentVersionNameDefinition.replace("libraryVersion=", "")
+    logger.info "Found current version name $currentVersionName"
+
+    String newVersionName = resolveNewVersionName.apply(currentVersionName)
+
+    if (newVersionName == currentVersionName) {
+        logger.lifecycle "versionName is already $currentVersionName; making no changes"
+        return
+    }
+
+    String newVersionNameDefinition = "libraryVersion=$newVersionName"
+    String newFileText = fileText.replace(currentVersionNameDefinition, newVersionNameDefinition)
+
+    logger.lifecycle "Changing versionName from $currentVersionName to $newVersionName"
+    versionFile.setText(newFileText)
+}

--- a/publish.gradle
+++ b/publish.gradle
@@ -17,8 +17,8 @@
 // Applied per published module
 //  The module must define ext.artifactName and ext.publishedDescription
 
-group = rootProject.ext.publishGroup
-version = rootProject.ext.libraryVersion
+group = rootProject.publishGroup
+version = rootProject.libraryVersion
 
 apply plugin: 'io.gitlab.arturbosch.detekt'
 detekt {


### PR DESCRIPTION
Convert the release process to require a reviewed PR for the release changes (i.e. version bump, changelog update, and optional readme updates). Closes #75.

Changes include:
* Library version defined in gradle.properties instead of build.gradle
* Adds a root `bumpToNextDevelopmentVersion` Gradle task which parses the current version and bumps it to the next snapshot version.
* Updates the release.yml Action to only release either tags or snapshots.
* Adds a post-release Action to committing a development version bump to main.
* Uses the default GITHUB_TOKEN for doc publication.
* AGP 7.0.0-beta05
* Updates RELEASING.md to reflect the new release process.

I tested the updated Actions on this branch before opening this PR, and then reverted the Actions to only run on main.