### PR TITLE
Update emulator runner

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,7 +30,7 @@ jobs:
           sarif_file: ${{ github.workspace }}/build/detekt/sarif
           checkout_path: ${{ github.workspace }}
       - name: Instrumented tests
-        uses: reactivecircus/android-emulator-runner@v2.15.0
+        uses: reactivecircus/android-emulator-runner@v2.19.1
         with:
           api-level: ${{ matrix.api-level }}
           script: ./gradlew connectedCheck -PciApiLevel=${{ matrix.api-level }} --stacktrace


### PR DESCRIPTION
Android Emulator Runner 2.19.1 for GitHub Actions, fixing a hanging build for API 28 & 29 emulators