### PR TITLE
Release 1.6.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # CHANGELOG
 
+## 1.6.0
+_2021-09-29_
+
+Introduce the `deferred-resources-animation-lottie` artifact for supporting Lottie animations. 
+This provides APIs for resolving existing Deferred Drawable types into a `LottieDrawable`.
+
+Compile with Kotlin 1.5.21 and AndroidX Core-KTX 1.5.0.
+
 ## 1.5.0
 _2021-07-03_
 

--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ repository](https://oss.sonatype.org/#view-repositories;snapshots~browsestorage)
 implementation "com.backbase.oss.deferredresources:deferred-resources:$version"
 implementation "com.backbase.oss.deferredresources:deferred-resources-view-extensions:$version"
 implementation "com.backbase.oss.deferredresources:deferred-resources-compose-adapter:$version"
+implementation "com.backbase.oss.deferredresources:deferred-resources-animation-lottie:$version"
 ```
 
 ## Use
@@ -84,7 +85,7 @@ All text-related types can eventually be converted to `DeferredText` through sim
 
 ### Jetpack Compose UI
 
-For each Deferred Resources type, the experimental `deferred-resource-compose-adapter` library
+For each Deferred Resources type, the experimental `deferred-resources-compose-adapter` library
 offers a `remember*` function to resolve the Deferred item to a standard Compose UI type.
 
 ```kotlin
@@ -95,6 +96,12 @@ val icon: Painter = rememberResolvedPainter(deferredDrawable)
 
 All of these APIs are marked as `@ExperimentalComposeAdapter` and should not be considered stable.
 Their behavior and binary compatibility are not guaranteed.
+
+### Lottie animations
+
+For each `Drawable` type, the `deferred-resources-animation-lottie` library offers a new
+`DeferredLottieDrawable` class which resolves [Lottie](https://github.com/airbnb/lottie-android) files
+into a `LottieDrawable`. This API is useful if one wishes to configure animations in their app.
 
 ## License
 ```

--- a/gradle.properties
+++ b/gradle.properties
@@ -34,7 +34,7 @@ publishGroup=com.backbase.oss.deferredresources
 # Actions for release to fail.
 #  Supported: 1.2.3, 1.3.0, 1.3.0-alpha01, 1.3.1-alpha01, 1.3.1-SNAPSHOT
 #  Not supported: 1.3.0-alpha.1, 1.3.0.1
-libraryVersion=1.6.0-SNAPSHOT
+libraryVersion=1.6.0
 
 # Whether the Compose adapter module is compiled with the project.
 composeEnabled=true


### PR DESCRIPTION
Followed these [release steps](https://github.com/Backbase/DeferredResources/blob/main/RELEASING.md)