### PR TITLE
Fix superscript and subscript in Compose text adapter

### DIFF
--- a/deferred-resources-compose-adapter/src/androidTest/java/com/backbase/deferredresources/compose/DeferredTextAdapterTest.kt
+++ b/deferred-resources-compose-adapter/src/androidTest/java/com/backbase/deferredresources/compose/DeferredTextAdapterTest.kt
@@ -30,6 +30,7 @@ import androidx.compose.ui.text.style.BaselineShift
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.style.TextDecoration
 import androidx.compose.ui.text.style.TextGeometricTransform
+import androidx.compose.ui.unit.em
 import com.backbase.deferredresources.DeferredText
 import com.backbase.deferredresources.compose.test.GenericValueNode
 import com.backbase.deferredresources.compose.test.R
@@ -150,21 +151,9 @@ internal class DeferredTextAdapterTest {
                 AnnotatedString.Range(item = SpanStyle(fontFamily = FontFamily.SansSerif), start = 86, end = 97),
                 AnnotatedString.Range(item = SpanStyle(fontFamily = FontFamily.Serif), start = 98, end = 104),
                 AnnotatedString.Range(item = SpanStyle(fontFamily = FontFamily.Serif), start = 208, end = 223),
-                AnnotatedString.Range(
-                    item = SpanStyle(textGeometricTransform = TextGeometricTransform(scaleX = 1.25f, skewX = 0f)),
-                    start = 156,
-                    end = 159,
-                ),
-                AnnotatedString.Range(
-                    item = SpanStyle(textGeometricTransform = TextGeometricTransform(scaleX = 0.8f, skewX = 0f)),
-                    start = 163,
-                    end = 168,
-                ),
-                AnnotatedString.Range(
-                    item = SpanStyle(textGeometricTransform = TextGeometricTransform(scaleX = 0.8f, skewX = 0f)),
-                    start = 213,
-                    end = 214,
-                ),
+                AnnotatedString.Range(item = SpanStyle(fontSize = 1.25f.em), start = 156, end = 159),
+                AnnotatedString.Range(item = SpanStyle(fontSize = 0.8f.em), start = 163, end = 168),
+                AnnotatedString.Range(item = SpanStyle(fontSize = 0.8f.em), start = 213, end = 214),
             ),
         )
         composeTestRule.onNodeWithTag(TestTag).assertGenericValueSemanticallyMatches<AnnotatedString> { value ->

--- a/deferred-resources-compose-adapter/src/main/java/com/backbase/deferredresources/compose/DeferredTextAdapter.kt
+++ b/deferred-resources-compose-adapter/src/main/java/com/backbase/deferredresources/compose/DeferredTextAdapter.kt
@@ -40,6 +40,7 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.BaselineShift
 import androidx.compose.ui.text.style.TextDecoration
 import androidx.compose.ui.text.style.TextGeometricTransform
+import androidx.compose.ui.unit.em
 import com.backbase.deferredresources.DeferredText
 import com.backbase.deferredresources.text.resolveToString
 
@@ -108,8 +109,7 @@ private fun CharacterStyle.toSpanStyle(): SpanStyle? = when (this) {
     is SubscriptSpan -> SpanStyle(baselineShift = BaselineShift.Subscript)
     is ForegroundColorSpan -> SpanStyle(color = Color(foregroundColor))
     is TypefaceSpan -> SpanStyle(fontFamily = fontFamily)
-    // TODO: Scale on Y axis too for RelativeSizeSpan
-    is RelativeSizeSpan -> SpanStyle(textGeometricTransform = TextGeometricTransform(scaleX = sizeChange))
+    is RelativeSizeSpan -> SpanStyle(fontSize = sizeChange.em)
     else -> null
 }
 


### PR DESCRIPTION
The `em` font size unit scales the text as expected, whereas the previously-used `TextGeometricTransform` only scaled the x-axis.