### PR TITLE
Rag 1845

### DIFF
--- a/deferred-resources/src/main/java/com/backbase/deferredresources/text/FormattedDeferredPlurals.kt
+++ b/deferred-resources/src/main/java/com/backbase/deferredresources/text/FormattedDeferredPlurals.kt
@@ -35,7 +35,7 @@ import kotlinx.parcelize.RawValue
  * A quantity must still be provided when resolved.
  */
 @Suppress("unused")
-@Deprecated("Covariant return type introduced", level = DeprecationLevel.HIDDEN)
+@Deprecated("Covariant return type introduced", level = DeprecationLevel.ERROR)
 // Unused generic is added to allow return-type overload
 @JvmSynthetic public fun <T> DeferredFormattedPlurals.withFormatArgs(vararg formatArgs: Any): DeferredPlurals =
     FormattedDeferredPlurals(wrapped = this, formatArgs = formatArgs)

--- a/deferred-resources/src/main/java/com/backbase/deferredresources/text/FormattedDeferredPlurals.kt
+++ b/deferred-resources/src/main/java/com/backbase/deferredresources/text/FormattedDeferredPlurals.kt
@@ -35,7 +35,14 @@ import kotlinx.parcelize.RawValue
  * A quantity must still be provided when resolved.
  */
 @Suppress("unused")
-@Deprecated("Covariant return type introduced", level = DeprecationLevel.ERROR)
+@Deprecated(
+    message = "Covariant return type introduced",
+    level = DeprecationLevel.ERROR,
+    replaceWith = ReplaceWith(
+        "withFormatArgs(vararg formatArgs: Any): FormattedDeferredPlurals",
+        "com.backbase.deferredresources.text.FormattedDeferredPlurals"
+    )
+)
 // Unused generic is added to allow return-type overload
 @JvmSynthetic public fun <T> DeferredFormattedPlurals.withFormatArgs(vararg formatArgs: Any): DeferredPlurals =
     FormattedDeferredPlurals(wrapped = this, formatArgs = formatArgs)

--- a/deferred-resources/src/main/java/com/backbase/deferredresources/text/FormattedDeferredText.kt
+++ b/deferred-resources/src/main/java/com/backbase/deferredresources/text/FormattedDeferredText.kt
@@ -33,7 +33,7 @@ import kotlinx.parcelize.RawValue
  * Convert a [DeferredFormattedString] to a normal [DeferredText] by providing [formatArgs] to be used when resolved.
  */
 @Suppress("unused")
-@Deprecated("Covariant return type introduced", level = DeprecationLevel.HIDDEN)
+@Deprecated("Covariant return type introduced", level = DeprecationLevel.ERROR)
 // Unused generic is added to allow return-type overload
 @JvmSynthetic public fun <T> DeferredFormattedString.withFormatArgs(vararg formatArgs: Any): DeferredText =
     FormattedDeferredText(wrapped = this, formatArgs = formatArgs)

--- a/deferred-resources/src/main/java/com/backbase/deferredresources/text/FormattedDeferredText.kt
+++ b/deferred-resources/src/main/java/com/backbase/deferredresources/text/FormattedDeferredText.kt
@@ -33,7 +33,14 @@ import kotlinx.parcelize.RawValue
  * Convert a [DeferredFormattedString] to a normal [DeferredText] by providing [formatArgs] to be used when resolved.
  */
 @Suppress("unused")
-@Deprecated("Covariant return type introduced", level = DeprecationLevel.ERROR)
+@Deprecated(
+    message = "Covariant return type introduced",
+    level = DeprecationLevel.ERROR,
+    replaceWith = ReplaceWith(
+        "withFormatArgs(vararg formatArgs: Any): FormattedDeferredText",
+        "com.backbase.deferredresources.text.FormattedDeferredText"
+    )
+)
 // Unused generic is added to allow return-type overload
 @JvmSynthetic public fun <T> DeferredFormattedString.withFormatArgs(vararg formatArgs: Any): DeferredText =
     FormattedDeferredText(wrapped = this, formatArgs = formatArgs)

--- a/deferred-resources/src/main/java/com/backbase/deferredresources/text/QuantifiedDeferredFormattedString.kt
+++ b/deferred-resources/src/main/java/com/backbase/deferredresources/text/QuantifiedDeferredFormattedString.kt
@@ -35,7 +35,14 @@ import kotlinx.parcelize.RawValue
  * resolved. Format arguments must still be provided when resolved.
  */
 @Suppress("unused")
-@Deprecated("Covariant return type introduced", level = DeprecationLevel.ERROR)
+@Deprecated(
+    message = "Covariant return type introduced",
+    level = DeprecationLevel.ERROR,
+    replaceWith = ReplaceWith(
+        "QuantifiedDeferredFormattedString(wrapped = this, quantity = quantity)",
+        "com.backbase.deferredresources.text.QuantifiedDeferredFormattedString"
+    )
+)
 // Unused generic is added to allow return-type overload
 @JvmSynthetic public fun <T> DeferredFormattedPlurals.withQuantity(quantity: Int): DeferredFormattedString =
     QuantifiedDeferredFormattedString(wrapped = this, quantity = quantity)

--- a/deferred-resources/src/main/java/com/backbase/deferredresources/text/QuantifiedDeferredFormattedString.kt
+++ b/deferred-resources/src/main/java/com/backbase/deferredresources/text/QuantifiedDeferredFormattedString.kt
@@ -35,7 +35,7 @@ import kotlinx.parcelize.RawValue
  * resolved. Format arguments must still be provided when resolved.
  */
 @Suppress("unused")
-@Deprecated("Covariant return type introduced", level = DeprecationLevel.HIDDEN)
+@Deprecated("Covariant return type introduced", level = DeprecationLevel.ERROR)
 // Unused generic is added to allow return-type overload
 @JvmSynthetic public fun <T> DeferredFormattedPlurals.withQuantity(quantity: Int): DeferredFormattedString =
     QuantifiedDeferredFormattedString(wrapped = this, quantity = quantity)

--- a/deferred-resources/src/main/java/com/backbase/deferredresources/text/QuantifiedDeferredText.kt
+++ b/deferred-resources/src/main/java/com/backbase/deferredresources/text/QuantifiedDeferredText.kt
@@ -33,7 +33,7 @@ import kotlinx.parcelize.RawValue
  * Convert a [DeferredPlurals] to a normal [DeferredText] by providing a [quantity] to be used when resolved.
  */
 @Suppress("unused")
-@Deprecated("Covariant return type introduced", level = DeprecationLevel.HIDDEN)
+@Deprecated("Covariant return type introduced", level = DeprecationLevel.ERROR)
 // Unused generic is added to allow return-type overload
 @JvmSynthetic public fun <T> DeferredPlurals.withQuantity(quantity: Int): DeferredText =
     QuantifiedDeferredText(wrapped = this, quantity = quantity)

--- a/deferred-resources/src/main/java/com/backbase/deferredresources/text/QuantifiedDeferredText.kt
+++ b/deferred-resources/src/main/java/com/backbase/deferredresources/text/QuantifiedDeferredText.kt
@@ -33,7 +33,14 @@ import kotlinx.parcelize.RawValue
  * Convert a [DeferredPlurals] to a normal [DeferredText] by providing a [quantity] to be used when resolved.
  */
 @Suppress("unused")
-@Deprecated("Covariant return type introduced", level = DeprecationLevel.ERROR)
+@Deprecated(
+    message = "Covariant return type introduced",
+    level = DeprecationLevel.ERROR,
+    replaceWith = ReplaceWith(
+        "withQuantity(quantity: Int): QuantifiedDeferredText",
+        "com.backbase.deferredresources.text.QuantifiedDeferredText"
+    )
+)
 // Unused generic is added to allow return-type overload
 @JvmSynthetic public fun <T> DeferredPlurals.withQuantity(quantity: Int): DeferredText =
     QuantifiedDeferredText(wrapped = this, quantity = quantity)

--- a/deferred-resources/src/main/java/com/backbase/deferredresources/text/QuantifiedFormattedDeferredText.kt
+++ b/deferred-resources/src/main/java/com/backbase/deferredresources/text/QuantifiedFormattedDeferredText.kt
@@ -41,7 +41,14 @@ import kotlinx.parcelize.RawValue
  * when resolved.
  */
 @Suppress("unused")
-@Deprecated("Covariant return type introduced", level = DeprecationLevel.ERROR)
+@Deprecated(
+    message = "Covariant return type introduced",
+    level = DeprecationLevel.ERROR,
+    replaceWith = ReplaceWith(
+        "withQuantityAndFormatArgs(quantity: Int,vararg formatArgs: Any = arrayOf(quantity))",
+        "com.backbase.deferredresources.text.QuantifiedFormattedDeferredText"
+    )
+)
 // Unused generic is added to allow return-type overload
 @JvmSynthetic public fun <T> DeferredFormattedPlurals.withQuantityAndFormatArgs(
     quantity: Int,

--- a/deferred-resources/src/main/java/com/backbase/deferredresources/text/QuantifiedFormattedDeferredText.kt
+++ b/deferred-resources/src/main/java/com/backbase/deferredresources/text/QuantifiedFormattedDeferredText.kt
@@ -41,7 +41,7 @@ import kotlinx.parcelize.RawValue
  * when resolved.
  */
 @Suppress("unused")
-@Deprecated("Covariant return type introduced", level = DeprecationLevel.HIDDEN)
+@Deprecated("Covariant return type introduced", level = DeprecationLevel.ERROR)
 // Unused generic is added to allow return-type overload
 @JvmSynthetic public fun <T> DeferredFormattedPlurals.withQuantityAndFormatArgs(
     quantity: Int,


### PR DESCRIPTION
Deprecating code for major release.  Code which was previously deprecated before 2021.07 release is updated with level=Deprecated.ERROR