### PR TITLE
Compile SDK 33

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -40,6 +40,7 @@ buildscript {
 }
 
 ext {
+    compileSdk = 33
     minSdk = 14
     minSdkLottie = 16
     minSdkCompose = 21

--- a/deferred-resources-animation-lottie/build.gradle
+++ b/deferred-resources-animation-lottie/build.gradle
@@ -30,7 +30,6 @@ android {
 
     defaultConfig {
         minSdkVersion rootProject.ext.minSdkLottie
-        targetSdkVersion rootProject.ext.targetSdk
         versionName version
 
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"

--- a/deferred-resources-animation-lottie/build.gradle
+++ b/deferred-resources-animation-lottie/build.gradle
@@ -25,7 +25,7 @@ ext {
 apply from: '../publish.gradle'
 
 android {
-    compileSdkVersion rootProject.ext.targetSdk
+    compileSdkVersion rootProject.ext.compileSdk
     buildToolsVersion rootProject.ext.buildToolsVersion
 
     defaultConfig {

--- a/deferred-resources-compose-adapter/build.gradle
+++ b/deferred-resources-compose-adapter/build.gradle
@@ -31,7 +31,6 @@ android {
 
     defaultConfig {
         minSdkVersion rootProject.ext.minSdkCompose
-        targetSdkVersion rootProject.ext.targetSdk
         versionName version
 
         consumerProguardFiles "consumer-rules.pro"

--- a/deferred-resources-compose-adapter/build.gradle
+++ b/deferred-resources-compose-adapter/build.gradle
@@ -26,7 +26,7 @@ ext {
 apply from: "../publish.gradle"
 
 android {
-    compileSdkVersion rootProject.ext.targetSdk
+    compileSdkVersion rootProject.ext.compileSdk
     buildToolsVersion rootProject.ext.buildToolsVersion
 
     defaultConfig {

--- a/deferred-resources-view-extensions/build.gradle
+++ b/deferred-resources-view-extensions/build.gradle
@@ -24,7 +24,7 @@ ext {
 apply from: '../publish.gradle'
 
 android {
-    compileSdkVersion rootProject.ext.targetSdk
+    compileSdkVersion rootProject.ext.compileSdk
     buildToolsVersion rootProject.ext.buildToolsVersion
 
     defaultConfig {

--- a/deferred-resources/build.gradle
+++ b/deferred-resources/build.gradle
@@ -26,7 +26,7 @@ ext {
 apply from: '../publish.gradle'
 
 android {
-    compileSdkVersion rootProject.ext.targetSdk
+    compileSdkVersion rootProject.ext.compileSdk
     buildToolsVersion rootProject.ext.buildToolsVersion
 
     defaultConfig {

--- a/deferred-resources/build.gradle
+++ b/deferred-resources/build.gradle
@@ -31,7 +31,6 @@ android {
 
     defaultConfig {
         minSdkVersion rootProject.ext.minSdk
-        targetSdkVersion rootProject.ext.targetSdk
         versionName version
 
         consumerProguardFiles 'consumer-rules.pro'

--- a/demo-compose/build.gradle
+++ b/demo-compose/build.gradle
@@ -18,7 +18,7 @@ apply plugin: 'com.android.application'
 apply plugin: 'org.jetbrains.kotlin.android'
 
 android {
-    compileSdkVersion rootProject.ext.targetSdk
+    compileSdkVersion rootProject.ext.compileSdk
     buildToolsVersion rootProject.ext.buildToolsVersion
 
     defaultConfig {

--- a/demo-core/build.gradle
+++ b/demo-core/build.gradle
@@ -18,7 +18,7 @@ apply plugin: 'com.android.library'
 apply plugin: 'org.jetbrains.kotlin.android'
 
 android {
-    compileSdkVersion rootProject.ext.targetSdk
+    compileSdkVersion rootProject.ext.compileSdk
     buildToolsVersion rootProject.ext.buildToolsVersion
 
     defaultConfig {

--- a/demo/build.gradle
+++ b/demo/build.gradle
@@ -18,7 +18,7 @@ apply plugin: 'com.android.application'
 apply plugin: 'org.jetbrains.kotlin.android'
 
 android {
-    compileSdkVersion rootProject.ext.targetSdk
+    compileSdkVersion rootProject.ext.compileSdk
     buildToolsVersion rootProject.ext.buildToolsVersion
 
     defaultConfig {


### PR DESCRIPTION
Updates the tooling used to build the libraries. Compile SDK does not affect consuming apps' required versions.

Target SDK *does* affect consuming apps' required versions, and there's no need for Deferred Resources to force a target SDK on consuming apps, so target SDKs are removed from the libraries in this PR too.