### PR TITLE
Speed up CI builds

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,6 +31,8 @@ jobs:
         with:
           sarif_file: ${{ github.workspace }}/build/detekt/sarif
           checkout_path: ${{ github.workspace }}
+      - name: Install HAXM
+        run: brew install --cask intel-haxm
       - name: Emulator cache
         uses: actions/cache@v3
         id: avd-cache

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,7 +28,7 @@ jobs:
       - name: Build
         run: ./gradlew clean build -PciApiLevel=${{ matrix.api-level }} --stacktrace
       - name: Report Detekt results
-        uses: github/codeql-action/upload-sarif@v1
+        uses: github/codeql-action/upload-sarif@v2
         with:
           sarif_file: ${{ github.workspace }}/build/detekt/sarif
           checkout_path: ${{ github.workspace }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,8 +19,9 @@ jobs:
       - name: Validate Gradle wrapper
         uses: gradle/wrapper-validation-action@v1
       - name: Install JDK 11
-        uses: actions/setup-java@v1
+        uses: actions/setup-java@v3
         with:
+          distribution: zulu
           java-version: 11
       - name: Gradle cache
         uses: gradle/gradle-build-action@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,6 +22,8 @@ jobs:
         uses: actions/setup-java@v1
         with:
           java-version: 11
+      - name: Gradle cache
+        uses: gradle/gradle-build-action@v2
       - name: Build
         run: ./gradlew clean build -PciApiLevel=${{ matrix.api-level }} --stacktrace
       - name: Report Detekt results
@@ -29,10 +31,30 @@ jobs:
         with:
           sarif_file: ${{ github.workspace }}/build/detekt/sarif
           checkout_path: ${{ github.workspace }}
-      - name: Instrumented tests
-        uses: reactivecircus/android-emulator-runner@v2.19.1
+      - name: Emulator cache
+        uses: actions/cache@v3
+        id: avd-cache
+        with:
+          path: |
+            ~/.android/avd/*
+            ~/.android/adb*
+          key: avd-${{ matrix.api-level }}
+      - name: Create emulator and generate snapshot for caching
+        if: steps.avd-cache.outputs.cache-hit != 'true'
+        uses: reactivecircus/android-emulator-runner@v2
         with:
           api-level: ${{ matrix.api-level }}
+          force-avd-creation: false
+          emulator-options: -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none
+          disable-animations: false
+          script: echo "Generated AVD snapshot for caching."
+      - name: Instrumented tests
+        uses: reactivecircus/android-emulator-runner@v2
+        with:
+          api-level: ${{ matrix.api-level }}
+          force-avd-creation: false
+          emulator-options: -no-snapshot-save -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none
+          disable-animations: true
           script: ./gradlew connectedCheck -PciApiLevel=${{ matrix.api-level }} --stacktrace
       - name: Publish test results
         uses: mikepenz/action-junit-report@v1.2.1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -33,6 +33,8 @@ jobs:
         uses: actions/checkout@v2
       - name: Validate Gradle wrapper
         uses: gradle/wrapper-validation-action@v1
+      - name: Gradle cache
+        uses: gradle/gradle-build-action@v2
       - name: Assemble for release
         run: ./gradlew clean assembleRelease --stacktrace
       - name: Publish

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -33,6 +33,11 @@ jobs:
         uses: actions/checkout@v2
       - name: Validate Gradle wrapper
         uses: gradle/wrapper-validation-action@v1
+      - name: Install JDK 11
+        uses: actions/setup-java@v3
+        with:
+          distribution: zulu
+          java-version: 11
       - name: Gradle cache
         uses: gradle/gradle-build-action@v2
       - name: Assemble for release


### PR DESCRIPTION
They've gotten quite slow for a few reasons. This PR:
* Enables the Gradle cache, which should speed up the "Build" step. The Gradle cache only caches on the main branch, so we won't see how well this works until after it is merged.
* Enables the AVD cache and adds some speedier options to the existing "Instrumented tests" step. See the suggestions in the Android emulator runner's [readme](https://github.com/ReactiveCircus/android-emulator-runner/blob/v2.27.0/README.md#usage--examples).
* Installs HAXM on build machines, which may further improve emulator speed. See the related paragraph in the Android emulator runner's [readme](https://github.com/ReactiveCircus/android-emulator-runner/blob/v2.27.0/README.md#haxm-support-on-githubs-macos-runners).
* Updates to `setup-java@v3`.
* Updates to `upload-sarif@v2`