### PR TITLE
Don't run clean builds on CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,7 +26,7 @@ jobs:
       - name: Gradle cache
         uses: gradle/gradle-build-action@v2
       - name: Build
-        run: ./gradlew clean build -PciApiLevel=${{ matrix.api-level }} --stacktrace
+        run: ./gradlew build -PciApiLevel=${{ matrix.api-level }} --stacktrace
       - name: Report Detekt results
         uses: github/codeql-action/upload-sarif@v2
         with:


### PR DESCRIPTION
I forgot this on #90. This should make it so the Gradle cache is actually worth something. Let's see!